### PR TITLE
Fix group membership check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
 
   def member_of?(group)
     membership = membership_for(group)
-    membership && !membership.newbie?
+    membership && membership.active?
   end
 
   def roles


### PR DESCRIPTION
To check someone's group membership, we should verify that membership is not finished or archived.