### PR TITLE
Fix photo path when no cropped provided

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -3,7 +3,7 @@ class PhotosController < ApplicationController
 
   def show
     sanitized = params[:id].gsub(/^.*(\\|\/)/, '')
-    send_file PhotoService.cropped_path(sanitized), type: 'image/png', disposition: 'inline'
+    send_file PhotoService.photo_path(sanitized), type: 'image/png', disposition: 'inline'
   end
 
   def update

--- a/app/services/photo_service.rb
+++ b/app/services/photo_service.rb
@@ -22,8 +22,13 @@ module PhotoService extend self
   end
 
   def cropped_path(screen_name)
-    return default_path unless Dir.exists?(photo_dir(screen_name))
     photo_dir(screen_name).join('cropped.png')
+  end
+
+  def photo_path(screen_name)
+    path = cropped_path(screen_name)
+    return default_path unless File.file?(path)
+    path
   end
 
   def raw_check(screen_name)


### PR DESCRIPTION
Fixes broken photo requests. Cropped photo doesn't exist while cropping or if the user skips saving the cropped.