### PR TITLE
Fix point history

### DIFF
--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -5,8 +5,8 @@ module ProfilesHelper
     end
   end
 
-  def years_with_points(pointrequests)
-    pointrequests.map { |request| request.evaluation.semester }
+  def years_with_points(point_history)
+    point_history.map { |history| history.semester }
                  .uniq.sort.reverse.each do |semester|
       yield Semester.new(semester)
     end

--- a/app/views/profiles/_point_history.html.erb
+++ b/app/views/profiles/_point_history.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <div class="uk-accordion" data-uk-accordion="{collapse:false, showfirst:false}">
-  <% years_with_points(@user_presenter.pointrequests) do |year| %>
+  <% years_with_points(@user_presenter.point_history) do |year| %>
   <div class="uk-accordion-title uk-clearfix">
     <div class="uk-float-left">
       <%= year.to_readable %>


### PR DESCRIPTION
Use point history table to determine years with points. This avoids the half finished evaluations to break the application.