### PR TITLE
Update justification edit behaviour

### DIFF
--- a/app/controllers/justifications_controller.rb
+++ b/app/controllers/justifications_controller.rb
@@ -6,6 +6,7 @@ class JustificationsController < EvaluationsController
   def edit
     @entry_requests = Evaluation.find(params[:evaluation_id]).entry_requests
       .select { |er| er.entry_type != EntryRequest::KDO }
+    redirect_back alert: t(:no_entry_request) if @entry_requests.empty?
   end
 
   def update

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -6,6 +6,7 @@ hu:
     formats:
       default: "%Y.%m.%d. %H:%M"
 
+  no_entry_request: Nincs belépőigény leadva!
   edit_successful: Sikeres mentés!
   register_successful: Sikeres regisztráció!
   too_many_delegates: Túl sok küldöttet szeretnél beállítani!


### PR DESCRIPTION
Redirects back, when there is not any entry request.

The error was originated from the empty form. It could be checked at update, but this solution gives better flow.