### PR TITLE
Move validation to point_detail model

### DIFF
--- a/app/controllers/point_details_controller.rb
+++ b/app/controllers/point_details_controller.rb
@@ -6,8 +6,9 @@ class PointDetailsController < ApplicationController
 
   def update
     point_request = PointRequest.find_or_create_by(evaluation: @evaluation, user: @user)
-    @point_detail = PointDetail.find_or_create_by(point_request: point_request, principle: @principle)
-    @point_detail.update(point: valid_point)
+    @point_detail = PointDetail.find_or_create_by(point_request: point_request,
+                                                  principle: @principle)
+    @point_detail.update(point: params[:point])
 
     @point_details = PointDetail.includes(%i[point_request principle]).select do |pd|
       pd.point_request.evaluation == @evaluation && pd.point_request.user_id == @user.id
@@ -20,14 +21,6 @@ class PointDetailsController < ApplicationController
     @user = User.find params[:user_id]
     @principle = Principle.find params[:principle_id]
     @evaluation = Evaluation.find params[:evaluation_id]
-  end
-
-  def valid_point
-    max_point = @principle.max_per_member
-    point = params[:point].to_i
-    return 0 if point < 0
-    return max_point if point > max_point
-    point
   end
 
   def changeable_evaluation

--- a/app/models/point_detail.rb
+++ b/app/models/point_detail.rb
@@ -4,7 +4,20 @@ class PointDetail < ActiveRecord::Base
   belongs_to :principle
   belongs_to :point_request
 
+  before_save do
+    self.point = valid_point
+  end
+
   after_save do
     point_request.recalculate!
+  end
+
+  private
+
+  def valid_point
+    return 0 if point.nil? || point < 0
+    max_point = principle.max_per_member
+    return max_point if point > max_point
+    point
   end
 end


### PR DESCRIPTION
It is better in the model and needed for fixing point request's point sum to finish point history calculation. It is fixing the null point error at the evaluation creation process, too. 