### PR TITLE
Apply new member post type when accepting membership

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -26,6 +26,10 @@ class Membership < ActiveRecord::Base
     has_post?(DEFAULT_POST_ID) && end_date.nil? && !archived?
   end
 
+  def new_member?
+    has_post?(NEW_MEMBER_ID) && active?
+  end
+
   def pek_admin?
     has_post?(PEK_ADMIN_ID)
   end
@@ -81,5 +85,6 @@ class Membership < ActiveRecord::Base
   def accept!
     newbie_post = posts.find { |post| post.post_type.id == DEFAULT_POST_ID }
     newbie_post.destroy
+    post_types << PostType.find(NEW_MEMBER_ID)
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -16,6 +16,7 @@ class Membership < ActiveRecord::Base
   PAST_LEADER_ID = 4
   DEFAULT_POST_ID = 6
   PEK_ADMIN_ID = 66
+  NEW_MEMBER_ID = 104
 
   def leader?
     has_post?(LEADER_POST_ID)

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,0 +1,24 @@
+namespace :data do
+  namespace :migrate do
+    desc 'Use for unifying new member post types'
+    task new_member_posts: :environment do
+      new_member_post_type_names = %w[újonc ujonc Újonc]
+      new_member_post_types = PostType.where(name: new_member_post_type_names)
+                                      .where.not(id: Membership::NEW_MEMBER_ID)
+                                      .includes(:group)
+
+      puts "\nThe following post types will be deleted:"
+      new_member_post_types.each { |type| puts "#{type.id} - #{type.name} / #{type.group.name}" }
+
+      puts 'Are you sure to continue? y/N'
+      input = STDIN.gets.chomp
+      raise 'Aborted!' unless %w[y yes].include? input.downcase
+
+      PostType.update(Membership::NEW_MEMBER_ID, group_id: nil)
+
+      Post.where(post_type_id: new_member_post_type_ids)
+          .update_all(pttip_id: Membership::NEW_MEMBER_ID)
+      new_member_post_types.delete_all
+    end
+  end
+end

--- a/test/fixtures/post_type.yml
+++ b/test/fixtures/post_type.yml
@@ -9,3 +9,7 @@ newbie:
 pek_admin:
   pttip_id: 66
   pttip_name: PéK Admin
+
+new_member:
+  pttip_id: 104
+  pttip_name: újonc

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -20,4 +20,17 @@ class MembershipTest < ActionController::TestCase
 
     assert_not membership.reload.user.delegated
   end
+
+  test 'accepting removes newbie post and sets new member post' do
+    membership = grp_membership(:newbie_membership)
+
+    assert membership.newbie?
+    assert_not membership.new_member?
+
+    membership.accept!
+    membership.reload
+
+    assert_not membership.newbie?
+    assert membership.new_member?
+  end
 end


### PR DESCRIPTION
I've used the following query to select the type names to migrate:
```sql
select * from poszttipus where pttip_name like '%jonc%';
```