### PR TITLE
Filter routing errors from Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -32,6 +32,8 @@ Rollbar.configure do |config|
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
+  config.exception_level_filters.merge!('ActionController::RoutingError' => 'ignore')
+
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)
   # config.use_async = true


### PR DESCRIPTION
What do you think about this? This way we can easily filter the routing errors and add Rollbar notifications to Slack without spamming it.