### PR TITLE
Normalize db column table names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
 end
 
 group :development do
+  gem 'annotate'
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    annotate (3.0.3)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     arel (7.1.4)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -281,6 +284,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   better_errors
   binding_of_caller
   brakeman

--- a/app/controllers/auth_sch_services_controller.rb
+++ b/app/controllers/auth_sch_services_controller.rb
@@ -12,14 +12,14 @@ class AuthSchServicesController < ApplicationController
   end
 
   def entrants
-    user = get_user(params[:id], [{ entryrequests: [{ evaluation: [:group] }] }])
+    user = get_user(params[:id], [{ entry_requests: [{ evaluation: [:group] }] }])
     render json: entrants_json(user, params[:semester]) if user
   end
 
   private
 
   def entrants_json(user, semester)
-    entrants = user.entryrequests.select do |er|
+    entrants = user.entry_requests.select do |er|
       er.evaluation.accepted && er.evaluation.semester == semester
     end
     entrant_array = []

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,7 @@ class ProfilesController < ApplicationController
   before_action :set_entities_for_edit, only: %i[edit]
 
   def show
-    user = User.includes([{ pointrequests: [{ evaluation: %i[group entry_requests] }] },
+    user = User.includes([{ point_requests: [{ evaluation: %i[group entry_requests] }] },
                           { memberships: %i[group post_types] }]).find_by(screen_name: params[:id])
     return redirect_to profiles_me_path unless user
 

--- a/app/decorators/group_member_decorator.rb
+++ b/app/decorators/group_member_decorator.rb
@@ -13,9 +13,9 @@ class GroupMemberDecorator < Draper::Decorator
   end
 
   def membership_time
-    return "#{l membership_start} - #{l membership_end}" if membership.inactive?
+    return "#{l start_date} - #{l end_date}" if membership.inactive?
 
-    "#{l membership_start} -"
+    "#{l start_date} -"
   end
 
   def edit_post_button(group)

--- a/app/decorators/im_account_decorator.rb
+++ b/app/decorators/im_account_decorator.rb
@@ -4,6 +4,6 @@ class ImAccountDecorator < Draper::Decorator
 
   def account
     humanized_protocol = ImAccount.human_attribute_name("protocol.#{protocol}")
-    content_tag(:h5, "#{humanized_protocol}: #{account_name}", class: 'uk-h5')
+    content_tag(:h5, "#{humanized_protocol}: #{name}", class: 'uk-h5')
   end
 end

--- a/app/models/entry_request.rb
+++ b/app/models/entry_request.rb
@@ -1,14 +1,6 @@
 class EntryRequest < ApplicationRecord
-  self.table_name = 'belepoigenyles'
-  self.primary_key = :id
-
-  alias_attribute :entry_type, :belepo_tipus
-  alias_attribute :justification, :szoveges_ertekeles
-  alias_attribute :evaluation_id, :ertekeles_id
-  alias_attribute :user_id, :usr_id
-
-  belongs_to :evaluation, foreign_key: :ertekeles_id
-  belongs_to :user, foreign_key: :usr_id
+  belongs_to :evaluation
+  belongs_to :user
 
   AB = 'AB'.freeze
   KB = 'KB'.freeze
@@ -20,7 +12,7 @@ class EntryRequest < ApplicationRecord
   end
 
   def self.remove_justifications
-    where(entry_type: KDO).update_all(szoveges_ertekeles: '')
+    where(entry_type: KDO).update_all(justification: '')
   end
 
   def accepted?

--- a/app/models/entry_request.rb
+++ b/app/models/entry_request.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: entry_requests
+#
+#  id            :bigint           not null, primary key
+#  entry_type    :string(255)
+#  justification :text
+#  evaluation_id :bigint           not null
+#  user_id       :bigint
+#
+
 class EntryRequest < ApplicationRecord
   belongs_to :evaluation
   belongs_to :user

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: evaluations
+#
+#  id                   :bigint           not null, primary key
+#  entry_request_status :string(255)
+#  timestamp            :datetime
+#  point_request_status :string(255)
+#  semester             :string(9)        not null
+#  justification        :text             not null
+#  last_evaulation      :datetime
+#  last_modification    :datetime
+#  reviewer_user_id     :bigint
+#  group_id             :bigint
+#  creator_user_id      :bigint
+#  principle            :text             default(""), not null
+#  next_version         :bigint
+#  explanation          :text
+#  optlock              :integer          default(0), not null
+#  is_considered        :boolean          default(FALSE), not null
+#
+
 class Evaluation < ApplicationRecord
   before_save :set_default_values
 

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,24 +1,11 @@
 class Evaluation < ApplicationRecord
-  self.table_name = 'ertekelesek'
-  self.primary_key = :id
-
   before_save :set_default_values
 
-  alias_attribute :entry_request_status, :belepoigeny_statusz
-  alias_attribute :timestamp, :feladas
-  alias_attribute :point_request_status, :pontigeny_statusz
-  alias_attribute :date, :semester # This alias is misleading
-  alias_attribute :justification, :szoveges_ertekeles
-  alias_attribute :last_evaulation, :utolso_elbiralas
-  alias_attribute :last_modification, :utolso_modositas
-  alias_attribute :reviewer_user_id, :elbiralo_usr_id
-  alias_attribute :group_id, :grp_id
-  alias_attribute :creator_user_id, :felado_usr_id
-  alias_attribute :principle, :pontozasi_elvek
+  alias_attribute :date, :semester
 
-  belongs_to :group, foreign_key: :grp_id
-  has_many :point_requests, foreign_key: :ertekeles_id, inverse_of: :evaluation
-  has_many :entry_requests, foreign_key: :ertekeles_id
+  belongs_to :group
+  has_many :point_requests
+  has_many :entry_requests
   has_many :principles
   has_many :ordered_principles, -> { order(:id) }, class_name: :Principle
 

--- a/app/models/evaluation_message.rb
+++ b/app/models/evaluation_message.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: evaluation_messages
+#
+#  id             :bigint           not null, primary key
+#  sent_at        :datetime
+#  message        :text
+#  sender_user_id :bigint
+#  group_id       :bigint
+#  semester       :string(9)        not null
+#  from_system    :boolean          default(FALSE)
+#
+
 class EvaluationMessage < ApplicationRecord
   belongs_to :group
   belongs_to :sender_user, class_name: 'User', foreign_key: :sender_user_id

--- a/app/models/evaluation_message.rb
+++ b/app/models/evaluation_message.rb
@@ -1,11 +1,4 @@
 class EvaluationMessage < ApplicationRecord
-  self.table_name = 'ertekeles_uzenet'
-  self.primary_key = :id
-
-  alias_attribute :sent_at, :feladas_ido
-  alias_attribute :message, :uzenet
-  alias_attribute :sender_user_id, :felado_usr_id
-
   belongs_to :group
-  belongs_to :sender_user, class_name: 'User', foreign_key: :felado_usr_id
+  belongs_to :sender_user, class_name: 'User', foreign_key: :sender_user_id
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,30 +1,16 @@
 class Group < ApplicationRecord
-  self.primary_key = :grp_id
   self.inheritance_column = nil
 
-  alias_attribute :id, :grp_id
-  alias_attribute :name, :grp_name
-  alias_attribute :parent_id, :grp_parent
-  alias_attribute :state, :grp_state
-  alias_attribute :description, :grp_description
-  alias_attribute :webpage, :grp_webpage
-  alias_attribute :maillist, :grp_maillist
-  alias_attribute :head, :grp_head
-  alias_attribute :founded, :grp_founded
-  alias_attribute :issvie, :grp_issvie
-  alias_attribute :delegate_count, :grp_svie_delegate_nr
-  alias_attribute :users_can_apply, :grp_users_can_apply
-  alias_attribute :archived_members_visible, :grp_archived_members_visible
   alias_attribute :parent, :group
 
-  has_many :memberships, foreign_key: :grp_id
+  has_many :memberships
   has_many :members, through: :memberships, source: :user
-  has_many :post_types, foreign_key: :grp_id
-  has_many :evaluations, foreign_key: :grp_id
+  has_many :post_types
+  has_many :evaluations
   has_many :point_requests, through: :evaluations
   has_many :entry_requests, through: :evaluations
-  has_many :children, class_name: :Group, foreign_key: :grp_parent
-  belongs_to :group, foreign_key: :grp_parent, optional: true
+  has_many :children, class_name: :Group
+  belongs_to :group, foreign_key: :parent_id, optional: true
   alias own_post_types post_types
 
   SVIE_ID = 369

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id                       :bigint           not null, primary key
+#  name                     :text             not null
+#  grp_type                 :string(20)
+#  parent_id                :bigint
+#  state                    :string           default("akt")
+#  description              :text
+#  webpage                  :string(64)
+#  maillist                 :string(64)
+#  head                     :string(48)
+#  founded                  :integer
+#  issvie                   :boolean          default(FALSE), not null
+#  delegate_count           :integer
+#  users_can_apply          :boolean          default(TRUE), not null
+#  archived_members_visible :boolean
+#  type                     :string
+#
+
 class Group < ApplicationRecord
   self.inheritance_column = nil
 

--- a/app/models/im_account.rb
+++ b/app/models/im_account.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: im_accounts
+#
+#  id       :bigint           not null, primary key
+#  protocol :string(50)       not null
+#  name     :string(255)      not null
+#  user_id  :bigint
+#
+
 class ImAccount < ApplicationRecord
   belongs_to :user
 end

--- a/app/models/im_account.rb
+++ b/app/models/im_account.rb
@@ -1,8 +1,3 @@
 class ImAccount < ApplicationRecord
-  self.primary_key = :id
-
-  alias_attribute :user_id, :usr_id
-  alias_attribute :name, :account_name
-
-  belongs_to :user, foreign_key: :usr_id
+  belongs_to :user
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: memberships
+#
+#  id         :bigint           not null, primary key
+#  group_id   :bigint
+#  user_id    :bigint
+#  start_date :date
+#  end_date   :date
+#  archived   :date
+#
+
 class Membership < ApplicationRecord
   belongs_to :group
   belongs_to :user

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,15 +1,7 @@
 class Membership < ApplicationRecord
-  self.table_name = 'grp_membership'
-  self.primary_key = :id
-
-  alias_attribute :group_id, :grp_id
-  alias_attribute :user_id, :usr_id
-  alias_attribute :start_date, :membership_start
-  alias_attribute :end_date, :membership_end
-
-  belongs_to :group, foreign_key: :grp_id
-  belongs_to :user, foreign_key: :usr_id
-  has_many :posts, foreign_key: :grp_member_id
+  belongs_to :group
+  belongs_to :user
+  has_many :posts
   has_many :post_types, through: :posts
 
   LEADER_POST_ID = 3

--- a/app/models/point_detail.rb
+++ b/app/models/point_detail.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: point_details
+#
+#  id               :integer          not null, primary key
+#  principle_id     :integer
+#  point_request_id :integer
+#  point            :integer
+#
+
 class PointDetail < ApplicationRecord
   belongs_to :principle
   belongs_to :point_request

--- a/app/models/point_detail.rb
+++ b/app/models/point_detail.rb
@@ -1,6 +1,4 @@
 class PointDetail < ApplicationRecord
-  self.primary_key = :id
-
   belongs_to :principle
   belongs_to :point_request
   has_many :point_detail_comments, dependent: :destroy

--- a/app/models/point_detail_comment.rb
+++ b/app/models/point_detail_comment.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: point_detail_comments
+#
+#  id              :integer          not null, primary key
+#  comment         :text
+#  user_id         :integer
+#  point_detail_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class PointDetailComment < ApplicationRecord
   belongs_to :user
   belongs_to :point_detail

--- a/app/models/point_history.rb
+++ b/app/models/point_history.rb
@@ -1,6 +1,3 @@
 class PointHistory < ApplicationRecord
-  self.table_name = 'point_history'
-  self.primary_key = :id
-
-  belongs_to :user, foreign_key: :usr_id
+  belongs_to :user
 end

--- a/app/models/point_history.rb
+++ b/app/models/point_history.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: point_histories
+#
+#  id       :bigint           not null, primary key
+#  user_id  :bigint           not null
+#  point    :integer          not null
+#  semester :string(9)        not null
+#
+
 class PointHistory < ApplicationRecord
   belongs_to :user
 end

--- a/app/models/point_request.rb
+++ b/app/models/point_request.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: point_requests
+#
+#  id            :bigint           not null, primary key
+#  point         :integer
+#  evaluation_id :bigint           not null
+#  user_id       :bigint
+#
+
 class PointRequest < ApplicationRecord
   belongs_to :evaluation
   belongs_to :user

--- a/app/models/point_request.rb
+++ b/app/models/point_request.rb
@@ -1,14 +1,7 @@
 class PointRequest < ApplicationRecord
-  self.table_name = 'pontigenyles'
-  self.primary_key = :id
-
-  alias_attribute :point, :pont
-  alias_attribute :evaluation_id, :ertekeles_id
-  alias_attribute :user_id, :usr_id
-
-  belongs_to :evaluation, foreign_key: :ertekeles_id
-  belongs_to :user, foreign_key: :usr_id
-  has_many :point_details, inverse_of: :point_request
+  belongs_to :evaluation
+  belongs_to :user
+  has_many :point_details
 
   validates :user, presence: true
   validates :evaluation, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,11 +1,5 @@
 class Post < ApplicationRecord
-  self.table_name = 'poszt'
-  self.primary_key = :id
-
-  alias_attribute :membership_id, :grp_member_id
-  alias_attribute :post_type_id, :pttip_id
-
-  belongs_to :post_type, foreign_key: :pttip_id
+  belongs_to :post_type
 
   def leader?
     post_type_id == Membership::LEADER_POST_ID

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id            :bigint           not null, primary key
+#  membership_id :bigint
+#  post_type_id  :bigint
+#
+
 class Post < ApplicationRecord
   belongs_to :post_type
 

--- a/app/models/post_type.rb
+++ b/app/models/post_type.rb
@@ -1,12 +1,5 @@
 class PostType < ApplicationRecord
-  self.table_name = 'poszttipus'
-  self.primary_key = :pttip_id
-
-  alias_attribute :id, :pttip_id
-  alias_attribute :name, :pttip_name
-  alias_attribute :group_id, :grp_id
-
-  belongs_to :group, foreign_key: :grp_id, optional: true
+  belongs_to :group, optional: true
 
   validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/post_type.rb
+++ b/app/models/post_type.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: post_types
+#
+#  id             :bigint           not null, primary key
+#  group_id       :bigint
+#  name           :string(30)       not null
+#  delegated_post :boolean          default(FALSE)
+#
+
 class PostType < ApplicationRecord
   belongs_to :group, optional: true
 

--- a/app/models/principle.rb
+++ b/app/models/principle.rb
@@ -1,5 +1,4 @@
 class Principle < ApplicationRecord
-  self.primary_key = :id
   self.inheritance_column = nil # So it won't try to interpret the type column as STI
 
   belongs_to :evaluation

--- a/app/models/principle.rb
+++ b/app/models/principle.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: principles
+#
+#  id             :integer          not null, primary key
+#  evaluation_id  :integer
+#  name           :string
+#  description    :string
+#  type           :string
+#  max_per_member :integer
+#
+
 class Principle < ApplicationRecord
   self.inheritance_column = nil # So it won't try to interpret the type column as STI
 

--- a/app/models/privacy.rb
+++ b/app/models/privacy.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: privacies
+#
+#  id             :bigint           not null, primary key
+#  user_id        :bigint           not null
+#  attribute_name :string(64)       not null
+#  visible        :boolean          default(FALSE), not null
+#
+
 class Privacy < ApplicationRecord
   belongs_to :user
 

--- a/app/models/privacy.rb
+++ b/app/models/privacy.rb
@@ -1,10 +1,5 @@
 class Privacy < ApplicationRecord
-  self.table_name = 'usr_private_attrs'
-  self.primary_key = :id
-
-  alias_attribute :attribute_name, :attr_name
-
-  belongs_to :user, foreign_key: :usr_id
+  belongs_to :user
 
   def self.for(user, attribute)
     find_by(attribute_name: attribute, user: user) ||

--- a/app/models/svie_post_request.rb
+++ b/app/models/svie_post_request.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: svie_post_requests
+#
+#  id          :integer          not null, primary key
+#  member_type :string
+#  user_id     :integer
+#
+
 class SviePostRequest < ApplicationRecord
   belongs_to :user
 

--- a/app/models/svie_post_request.rb
+++ b/app/models/svie_post_request.rb
@@ -1,5 +1,5 @@
 class SviePostRequest < ApplicationRecord
-  belongs_to :user, foreign_key: :usr_id
+  belongs_to :user
 
   def inside_member?
     member_type == SvieUser::INSIDE_MEMBER

--- a/app/models/system_attribute.rb
+++ b/app/models/system_attribute.rb
@@ -1,9 +1,4 @@
 class SystemAttribute < ApplicationRecord
-  self.table_name = 'system_attrs'
-  self.primary_key = :attributeid
-  alias_attribute :value, :attributevalue
-  alias_attribute :name, :attributename
-
   def self.semester
     Semester.new(find_by(name: 'szemeszter').value)
   end

--- a/app/models/system_attribute.rb
+++ b/app/models/system_attribute.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: system_attributes
+#
+#  id    :bigint           not null, primary key
+#  name  :string(255)      not null
+#  value :string(255)      not null
+#
+
 class SystemAttribute < ApplicationRecord
   def self.semester
     Semester.new(find_by(name: 'szemeszter').value)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,41 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  email                   :string(64)
+#  neptun                  :string
+#  firstname               :text             not null
+#  lastname                :text             not null
+#  nickname                :text
+#  svie_member_type        :string(255)      default("NEMTAG"), not null
+#  svie_primary_membership :bigint
+#  delegated               :boolean          default(FALSE), not null
+#  show_recommended_photo  :boolean          default(FALSE), not null
+#  screen_name             :string(50)       not null
+#  date_of_birth           :date
+#  gender                  :string(50)       default("NOTSPECIFIED"), not null
+#  student_status          :string(50)       default("UNKNOWN"), not null
+#  mother_name             :string(100)
+#  photo_path              :string(255)
+#  webpage                 :string(255)
+#  cell_phone              :string(50)
+#  home_address            :string(255)
+#  est_grad                :string(10)
+#  dormitory               :string(50)
+#  room                    :string(255)
+#  status                  :string(8)        default("INACTIVE"), not null
+#  password                :string(28)
+#  salt                    :string(12)
+#  last_login              :datetime
+#  auth_sch_id             :string
+#  bme_id                  :string
+#  usr_created_at          :datetime
+#  metascore               :integer
+#  place_of_birth          :string
+#  birth_name              :string
+#
+
 class User < ApplicationRecord
   scope :primary_svie_members, -> { where.not(svie_primary_membership: nil) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,53 +1,17 @@
 class User < ApplicationRecord
-  self.primary_key = :usr_id
   scope :primary_svie_members, -> { where.not(svie_primary_membership: nil) }
 
-  alias_attribute :id, :usr_id
-  alias_attribute :email, :usr_email
-  alias_attribute :neptun, :usr_neptun
-  alias_attribute :firstname, :usr_firstname
-  alias_attribute :lastname, :usr_lastname
-  alias_attribute :nickname, :usr_nickname
-  # TODO: there should be a better way to access all this SVIE stuff
-  alias_attribute :svie_state, :usr_svie_state
-  alias_attribute :svie_member_type, :usr_svie_member_type
-  alias_attribute :svie_primary_membership, :usr_svie_primary_membership
-  alias_attribute :delegated, :usr_delegated
-  alias_attribute :show_recommended_photo, :usr_show_recommended_photo
-  alias_attribute :screen_name, :usr_screen_name
-  alias_attribute :date_of_birth, :usr_date_of_birth
-  alias_attribute :place_of_birth, :usr_place_of_birth
-  alias_attribute :birth_name, :usr_birth_name
-  alias_attribute :gender, :usr_gender
-  alias_attribute :student_status, :usr_student_status
-  alias_attribute :mother_name, :usr_mother_name
-  alias_attribute :photo_path, :usr_photo_path
-  alias_attribute :webpage, :usr_webpage
-  alias_attribute :cell_phone, :usr_cell_phone
-  alias_attribute :home_address, :usr_home_address
-  alias_attribute :est_grad, :usr_est_grad
-  alias_attribute :dormitory, :usr_dormitory
-  alias_attribute :room, :usr_room
-  alias_attribute :confirm, :usr_confirm
-  alias_attribute :status, :usr_status
-  alias_attribute :password, :usr_password
-  alias_attribute :salt, :usr_salt
-  alias_attribute :last_login, :usr_lastlogin
-  alias_attribute :metascore, :usr_metascore
-  alias_attribute :auth_sch_id, :usr_auth_sch_id
-  alias_attribute :bme_id, :usr_bme_id
-
-  has_many :memberships, class_name: :Membership, foreign_key: :usr_id
+  has_many :memberships
   has_many :groups, through: :memberships
-  has_many :entryrequests, class_name: :EntryRequest, foreign_key: :usr_id
-  has_many :pointrequests, class_name: :PointRequest, foreign_key: :usr_id, inverse_of: :user
-  has_many :im_accounts, foreign_key: :usr_id
-  has_many :point_history, foreign_key: :usr_id
-  has_many :privacies, foreign_key: :usr_id
+  has_many :entry_requests
+  has_many :point_requests
+  has_many :im_accounts
+  has_many :point_history
+  has_many :privacies
 
   has_one :primary_membership, class_name: :Membership, foreign_key: :id,
-                               primary_key: :usr_svie_primary_membership
-  has_one :svie_post_request, foreign_key: :usr_id, primary_key: :id
+                               primary_key: :svie_primary_membership
+  has_one :svie_post_request
   has_one :view_setting
 
   validates :screen_name, uniqueness: {case_sensitive: false}

--- a/app/models/view_setting.rb
+++ b/app/models/view_setting.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: view_settings
+#
+#  id             :integer          not null, primary key
+#  user_id        :integer
+#  items_per_page :integer
+#  show_pictures  :boolean          default(TRUE)
+#  listing        :integer          default("list")
+#
+
 class ViewSetting < ApplicationRecord
   enum listing: %i[grid list]
 

--- a/app/services/calculate_point_history.rb
+++ b/app/services/calculate_point_history.rb
@@ -22,7 +22,7 @@ class CalculatePointHistory
 
   def calculate_points(user)
     user_points = {}
-    user.pointrequests
+    user.point_requests
         .includes([{ evaluation: [:group] }])
         .select { |r| valid_point_request?(r) }
         .each do |point_request|

--- a/app/services/count_delegates.rb
+++ b/app/services/count_delegates.rb
@@ -7,7 +7,7 @@ class CountDelegates
   private
 
   def reset_delegate_count
-    Group.update_all grp_svie_delegate_nr: 0
+    Group.update_all delegate_count: 0
   end
 
   def count_delegates

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -9,28 +9,28 @@ class SearchQuery
       ["%#{t}%".mb_chars.downcase.to_s] * user_query_for_one_keyword.count('?')
     end
     query = ([user_query_for_one_keyword] * term.split.size).join(' AND ')
-    User.where(query, *params).order('usr_metascore DESC NULLS LAST').offset(offset).limit(count)
+    User.where(query, *params).order('metascore DESC NULLS LAST').offset(offset).limit(count)
   end
 
   def group_search(term, offset)
     offset ||= 0
     count = Rails.configuration.x.results_per_page
-    query = 'lower(grp_name) LIKE ?'
+    query = 'lower(name) LIKE ?'
     param = "%#{term}%".mb_chars.downcase.to_s
-    Group.where(query, param).order(grp_name: :desc).offset(offset.to_i).limit(count)
+    Group.where(query, param).order(name: :desc).offset(offset.to_i).limit(count)
   end
 
   private
 
   def user_query_for_one_keyword
     <<-SQL.squish
-      (lower(usr_lastname) LIKE ?
-      OR lower(usr_firstname) LIKE ?
-      OR lower(usr_nickname) LIKE ?
-      OR lower(usr_email) LIKE ?
-      OR (usr_cell_phone LIKE ? AND length(?) >= 8 )
-      OR lower(usr_dormitory) LIKE ?
-      OR usr_room LIKE ?)
+      (lower(lastname) LIKE ?
+      OR lower(firstname) LIKE ?
+      OR lower(nickname) LIKE ?
+      OR lower(email) LIKE ?
+      OR (cell_phone LIKE ? AND length(?) >= 8 )
+      OR lower(dormitory) LIKE ?
+      OR room LIKE ?)
     SQL
   end
 end

--- a/app/viewmodels/group_member.rb
+++ b/app/viewmodels/group_member.rb
@@ -10,7 +10,7 @@ class GroupMember
     return 'archivált' if @membership.end_date && @membership.archived
     return 'tag' if @membership.post_types.empty?
 
-    @membership.post_types.map(&:pttip_name).join(', ')
+    @membership.post_types.map(&:name).join(', ')
   end
 
   def full_name
@@ -31,11 +31,11 @@ class GroupMember
     @membership.user.screen_name
   end
 
-  def membership_start
+  def start_date
     @membership.start_date
   end
 
-  def membership_end
+  def end_date
     @membership.end_date
   end
 

--- a/app/views/profiles/_point_history.html.erb
+++ b/app/views/profiles/_point_history.html.erb
@@ -20,7 +20,7 @@
 
   <div class="uk-accordion-content">
     <ul class="uk-list uk-list-line">
-      <% user_detailed_point_history(@user_presenter.pointrequests, year) do |point_history| %>
+      <% user_detailed_point_history(@user_presenter.point_requests, year) do |point_history| %>
       <% point_history_presenter = PointHistoryDecorator.decorate(point_history) %>
       <li>
         <div class="uk-clearfix">

--- a/app/workers/metascorer.rb
+++ b/app/workers/metascorer.rb
@@ -15,8 +15,8 @@ class Metascorer
   end
 
   def calculate_meta_score(user)
-    last_sem_point = PointHistory.find_by(usr_id: user.id, semester: SystemAttribute.semester.previous.to_s)
-    last_year_point = PointHistory.find_by(usr_id: user.id, semester: SystemAttribute.semester.previous.previous.to_s)
+    last_sem_point = PointHistory.find_by(user_id: user.id, semester: SystemAttribute.semester.previous.to_s)
+    last_year_point = PointHistory.find_by(user_id: user.id, semester: SystemAttribute.semester.previous.previous.to_s)
 
     metascore = 0
 

--- a/db/migrate/20200127202810_fix_database_naming.rb
+++ b/db/migrate/20200127202810_fix_database_naming.rb
@@ -1,0 +1,109 @@
+class FixDatabaseNaming < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :belepoigenyles, :entry_requests
+    rename_column :entry_requests, :belepo_tipus, :entry_type
+    rename_column :entry_requests, :szoveges_ertekeles, :justification
+    rename_column :entry_requests, :ertekeles_id, :evaluation_id
+    rename_column :entry_requests, :usr_id, :user_id
+
+    rename_table :ertekeles_uzenet, :evaluation_messages
+    rename_column :evaluation_messages, :feladas_ido, :sent_at
+    rename_column :evaluation_messages, :uzenet, :message
+    rename_column :evaluation_messages, :felado_usr_id, :sender_user_id
+
+    rename_table :ertekelesek, :evaluations
+    rename_column :evaluations, :belepoigeny_statusz, :entry_request_status
+    rename_column :evaluations, :feladas, :timestamp
+    rename_column :evaluations, :pontigeny_statusz, :point_request_status
+    rename_column :evaluations, :szoveges_ertekeles, :justification
+    rename_column :evaluations, :utolso_elbiralas, :last_evaulation
+    rename_column :evaluations, :utolso_modositas, :last_modification
+    rename_column :evaluations, :elbiralo_usr_id, :reviewer_user_id
+    rename_column :evaluations, :grp_id, :group_id
+    rename_column :evaluations, :felado_usr_id, :creator_user_id
+    rename_column :evaluations, :pontozasi_elvek, :principle
+
+    rename_column :groups, :grp_id, :id
+    rename_column :groups, :grp_name, :name
+    rename_column :groups, :grp_parent, :parent_id
+    rename_column :groups, :grp_state, :state
+    rename_column :groups, :grp_description, :description
+    rename_column :groups, :grp_webpage, :webpage
+    rename_column :groups, :grp_maillist, :maillist
+    rename_column :groups, :grp_head, :head
+    rename_column :groups, :grp_founded, :founded
+    rename_column :groups, :grp_issvie, :issvie
+    rename_column :groups, :grp_svie_delegate_nr, :delegate_count
+    rename_column :groups, :grp_users_can_apply, :users_can_apply
+    rename_column :groups, :grp_archived_members_visible, :archived_members_visible
+
+    rename_column :im_accounts, :usr_id, :user_id
+    rename_column :im_accounts, :account_name, :name
+
+    rename_table :grp_membership, :memberships
+    rename_column :memberships, :grp_id, :group_id
+    rename_column :memberships, :usr_id, :user_id
+    rename_column :memberships, :membership_start, :start_date
+    rename_column :memberships, :membership_end, :end_date
+
+    rename_table :point_history, :point_histories
+    rename_column :point_histories, :usr_id, :user_id
+
+    rename_table :pontigenyles, :point_requests
+    rename_column :point_requests, :pont, :point
+    rename_column :point_requests, :ertekeles_id, :evaluation_id
+    rename_column :point_requests, :usr_id, :user_id
+
+    rename_table :poszttipus, :post_types
+    rename_column :post_types, :pttip_id, :id
+    rename_column :post_types, :pttip_name, :name
+    rename_column :post_types, :grp_id, :group_id
+
+    rename_table :poszt, :posts
+    rename_column :posts, :grp_member_id, :membership_id
+    rename_column :posts, :pttip_id, :post_type_id
+
+    rename_table :usr_private_attrs, :privacies
+    rename_column :privacies, :attr_name, :attribute_name
+    rename_column :privacies, :usr_id, :user_id
+
+    rename_column :svie_post_requests, :usr_id, :user_id
+
+    rename_table :system_attrs, :system_attributes
+    rename_column :system_attributes, :attributeid, :id
+    rename_column :system_attributes, :attributevalue, :value
+    rename_column :system_attributes, :attributename, :name
+
+    rename_column :users, :usr_id, :id
+    rename_column :users, :usr_email, :email
+    rename_column :users, :usr_neptun, :neptun
+    rename_column :users, :usr_firstname, :firstname
+    rename_column :users, :usr_lastname, :lastname
+    rename_column :users, :usr_nickname, :nickname
+    rename_column :users, :usr_svie_member_type, :svie_member_type
+    rename_column :users, :usr_svie_primary_membership, :svie_primary_membership
+    rename_column :users, :usr_delegated, :delegated
+    rename_column :users, :usr_show_recommended_photo, :show_recommended_photo
+    rename_column :users, :usr_screen_name, :screen_name
+    rename_column :users, :usr_date_of_birth, :date_of_birth
+    rename_column :users, :usr_place_of_birth, :place_of_birth
+    rename_column :users, :usr_birth_name, :birth_name
+    rename_column :users, :usr_gender, :gender
+    rename_column :users, :usr_student_status, :student_status
+    rename_column :users, :usr_mother_name, :mother_name
+    rename_column :users, :usr_photo_path, :photo_path
+    rename_column :users, :usr_webpage, :webpage
+    rename_column :users, :usr_cell_phone, :cell_phone
+    rename_column :users, :usr_home_address, :home_address
+    rename_column :users, :usr_est_grad, :est_grad
+    rename_column :users, :usr_dormitory, :dormitory
+    rename_column :users, :usr_room, :room
+    rename_column :users, :usr_status, :status
+    rename_column :users, :usr_password, :password
+    rename_column :users, :usr_salt, :salt
+    rename_column :users, :usr_lastlogin, :last_login
+    rename_column :users, :usr_metascore, :metascore
+    rename_column :users, :usr_auth_sch_id, :auth_sch_id
+    rename_column :users, :usr_bme_id, :bme_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.9
--- Dumped by pg_dump version 9.6.9
+-- Dumped from database version 9.6.16
+-- Dumped by pg_dump version 12.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,28 +12,29 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
+SET default_tablespace = '';
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
 
 
 --
--- Name: belepoigenyles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: entry_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.belepoigenyles_id_seq
+CREATE SEQUENCE public.entry_requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -41,24 +42,18 @@ CREATE SEQUENCE public.belepoigenyles_id_seq
     CACHE 1;
 
 
-SET default_tablespace = '';
-
-SET default_with_oids = true;
-
 --
--- Name: belepoigenyles; Type: TABLE; Schema: public; Owner: -
+-- Name: entry_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.belepoigenyles (
-    id bigint DEFAULT nextval('public.belepoigenyles_id_seq'::regclass) NOT NULL,
-    belepo_tipus character varying(255),
-    szoveges_ertekeles text,
-    ertekeles_id bigint NOT NULL,
-    usr_id bigint
+CREATE TABLE public.entry_requests (
+    id bigint DEFAULT nextval('public.entry_requests_id_seq'::regclass) NOT NULL,
+    entry_type character varying(255),
+    justification text,
+    evaluation_id bigint NOT NULL,
+    user_id bigint
 );
 
-
-SET default_with_oids = false;
 
 --
 -- Name: eredmeny_tmp; Type: TABLE; Schema: public; Owner: -
@@ -71,10 +66,10 @@ CREATE TABLE public.eredmeny_tmp (
 
 
 --
--- Name: ertekeles_uzenet_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: evaluation_messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ertekeles_uzenet_id_seq
+CREATE SEQUENCE public.evaluation_messages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -82,17 +77,15 @@ CREATE SEQUENCE public.ertekeles_uzenet_id_seq
     CACHE 1;
 
 
-SET default_with_oids = true;
-
 --
--- Name: ertekeles_uzenet; Type: TABLE; Schema: public; Owner: -
+-- Name: evaluation_messages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ertekeles_uzenet (
-    id bigint DEFAULT nextval('public.ertekeles_uzenet_id_seq'::regclass) NOT NULL,
-    feladas_ido timestamp without time zone,
-    uzenet text,
-    felado_usr_id bigint,
+CREATE TABLE public.evaluation_messages (
+    id bigint DEFAULT nextval('public.evaluation_messages_id_seq'::regclass) NOT NULL,
+    sent_at timestamp without time zone,
+    message text,
+    sender_user_id bigint,
     group_id bigint,
     semester character varying(9) NOT NULL,
     from_system boolean DEFAULT false
@@ -100,10 +93,10 @@ CREATE TABLE public.ertekeles_uzenet (
 
 
 --
--- Name: ertekelesek_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: evaluations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ertekelesek_id_seq
+CREATE SEQUENCE public.evaluations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -112,22 +105,22 @@ CREATE SEQUENCE public.ertekelesek_id_seq
 
 
 --
--- Name: ertekelesek; Type: TABLE; Schema: public; Owner: -
+-- Name: evaluations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ertekelesek (
-    id bigint DEFAULT nextval('public.ertekelesek_id_seq'::regclass) NOT NULL,
-    belepoigeny_statusz character varying(255),
-    feladas timestamp without time zone,
-    pontigeny_statusz character varying(255),
+CREATE TABLE public.evaluations (
+    id bigint DEFAULT nextval('public.evaluations_id_seq'::regclass) NOT NULL,
+    entry_request_status character varying(255),
+    "timestamp" timestamp without time zone,
+    point_request_status character varying(255),
     semester character varying(9) NOT NULL,
-    szoveges_ertekeles text NOT NULL,
-    utolso_elbiralas timestamp without time zone,
-    utolso_modositas timestamp without time zone,
-    elbiralo_usr_id bigint,
-    grp_id bigint,
-    felado_usr_id bigint,
-    pontozasi_elvek text DEFAULT ''::text NOT NULL,
+    justification text NOT NULL,
+    last_evaulation timestamp without time zone,
+    last_modification timestamp without time zone,
+    reviewer_user_id bigint,
+    group_id bigint,
+    creator_user_id bigint,
+    principle text DEFAULT ''::text NOT NULL,
     next_version bigint,
     explanation text,
     optlock integer DEFAULT 0 NOT NULL,
@@ -164,20 +157,20 @@ CREATE SEQUENCE public.groups_grp_id_seq
 --
 
 CREATE TABLE public.groups (
-    grp_id bigint DEFAULT nextval('public.groups_grp_id_seq'::regclass) NOT NULL,
-    grp_name text NOT NULL,
+    id bigint DEFAULT nextval('public.groups_grp_id_seq'::regclass) NOT NULL,
+    name text NOT NULL,
     grp_type character varying(20),
-    grp_parent bigint,
-    grp_state character varying DEFAULT 'akt'::bpchar,
-    grp_description text,
-    grp_webpage character varying(64),
-    grp_maillist character varying(64),
-    grp_head character varying(48),
-    grp_founded integer,
-    grp_issvie boolean DEFAULT false NOT NULL,
-    grp_svie_delegate_nr integer,
-    grp_users_can_apply boolean DEFAULT true NOT NULL,
-    grp_archived_members_visible boolean,
+    parent_id bigint,
+    state character varying DEFAULT 'akt'::bpchar,
+    description text,
+    webpage character varying(64),
+    maillist character varying(64),
+    head character varying(48),
+    founded integer,
+    issvie boolean DEFAULT false NOT NULL,
+    delegate_count integer,
+    users_can_apply boolean DEFAULT true NOT NULL,
+    archived_members_visible boolean,
     type character varying
 );
 
@@ -192,22 +185,6 @@ CREATE SEQUENCE public.grp_members_seq
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-
-
-SET default_with_oids = false;
-
---
--- Name: grp_membership; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.grp_membership (
-    id bigint DEFAULT nextval('public.grp_members_seq'::regclass) NOT NULL,
-    grp_id bigint,
-    usr_id bigint,
-    membership_start date DEFAULT now(),
-    membership_end date,
-    archived date
-);
 
 
 --
@@ -241,8 +218,8 @@ CREATE SEQUENCE public.im_accounts_seq
 CREATE TABLE public.im_accounts (
     id bigint DEFAULT nextval('public.im_accounts_seq'::regclass) NOT NULL,
     protocol character varying(50) NOT NULL,
-    account_name character varying(255) NOT NULL,
-    usr_id bigint
+    name character varying(255) NOT NULL,
+    user_id bigint
 );
 
 
@@ -279,6 +256,20 @@ CREATE TABLE public.lostpw_tokens (
     created timestamp without time zone,
     token character varying(64),
     usr_id bigint NOT NULL
+);
+
+
+--
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.memberships (
+    id bigint DEFAULT nextval('public.grp_members_seq'::regclass) NOT NULL,
+    group_id bigint,
+    user_id bigint,
+    start_date date DEFAULT now(),
+    end_date date,
+    archived date
 );
 
 
@@ -359,14 +350,38 @@ CREATE SEQUENCE public.point_history_seq
 
 
 --
--- Name: point_history; Type: TABLE; Schema: public; Owner: -
+-- Name: point_histories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.point_history (
+CREATE TABLE public.point_histories (
     id bigint DEFAULT nextval('public.point_history_seq'::regclass) NOT NULL,
-    usr_id bigint NOT NULL,
+    user_id bigint NOT NULL,
     point integer NOT NULL,
     semester character varying(9) NOT NULL
+);
+
+
+--
+-- Name: point_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.point_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: point_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.point_requests (
+    id bigint DEFAULT nextval('public.point_requests_id_seq'::regclass) NOT NULL,
+    point integer,
+    evaluation_id bigint NOT NULL,
+    user_id bigint
 );
 
 
@@ -385,10 +400,10 @@ CREATE TABLE public.points_2017 (
 
 
 --
--- Name: pontigenyles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+-- Name: poszttipus_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.pontigenyles_id_seq
+CREATE SEQUENCE public.poszttipus_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -396,17 +411,15 @@ CREATE SEQUENCE public.pontigenyles_id_seq
     CACHE 1;
 
 
-SET default_with_oids = true;
-
 --
--- Name: pontigenyles; Type: TABLE; Schema: public; Owner: -
+-- Name: post_types; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.pontigenyles (
-    id bigint DEFAULT nextval('public.pontigenyles_id_seq'::regclass) NOT NULL,
-    pont integer,
-    ertekeles_id bigint NOT NULL,
-    usr_id bigint
+CREATE TABLE public.post_types (
+    id bigint DEFAULT nextval('public.poszttipus_seq'::regclass) NOT NULL,
+    group_id bigint,
+    name character varying(30) NOT NULL,
+    delegated_post boolean DEFAULT false
 );
 
 
@@ -422,40 +435,14 @@ CREATE SEQUENCE public.poszt_seq
     CACHE 1;
 
 
-SET default_with_oids = false;
-
 --
--- Name: poszt; Type: TABLE; Schema: public; Owner: -
+-- Name: posts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.poszt (
+CREATE TABLE public.posts (
     id bigint DEFAULT nextval('public.poszt_seq'::regclass) NOT NULL,
-    grp_member_id bigint,
-    pttip_id bigint
-);
-
-
---
--- Name: poszttipus_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.poszttipus_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: poszttipus; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.poszttipus (
-    pttip_id bigint DEFAULT nextval('public.poszttipus_seq'::regclass) NOT NULL,
-    grp_id bigint,
-    pttip_name character varying(30) NOT NULL,
-    delegated_post boolean DEFAULT false
+    membership_id bigint,
+    post_type_id bigint
 );
 
 
@@ -493,6 +480,30 @@ ALTER SEQUENCE public.principles_id_seq OWNED BY public.principles.id;
 
 
 --
+-- Name: privacies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.privacies_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: privacies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.privacies (
+    id bigint DEFAULT nextval('public.privacies_id_seq'::regclass) NOT NULL,
+    user_id bigint NOT NULL,
+    attribute_name character varying(64) NOT NULL,
+    visible boolean DEFAULT false NOT NULL
+);
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -518,7 +529,7 @@ CREATE TABLE public.spot_images (
 CREATE TABLE public.svie_post_requests (
     id integer NOT NULL,
     member_type character varying,
-    usr_id integer
+    user_id integer
 );
 
 
@@ -541,20 +552,16 @@ CREATE SEQUENCE public.svie_post_requests_id_seq
 ALTER SEQUENCE public.svie_post_requests_id_seq OWNED BY public.svie_post_requests.id;
 
 
-SET default_with_oids = true;
-
 --
--- Name: system_attrs; Type: TABLE; Schema: public; Owner: -
+-- Name: system_attributes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.system_attrs (
-    attributeid bigint NOT NULL,
-    attributename character varying(255) NOT NULL,
-    attributevalue character varying(255) NOT NULL
+CREATE TABLE public.system_attributes (
+    id bigint NOT NULL,
+    name character varying(255) NOT NULL,
+    value character varying(255) NOT NULL
 );
 
-
-SET default_with_oids = false;
 
 --
 -- Name: temp_belepo; Type: TABLE; Schema: public; Owner: -
@@ -582,71 +589,43 @@ CREATE SEQUENCE public.users_usr_id_seq
     CACHE 1;
 
 
-SET default_with_oids = true;
-
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.users (
-    usr_id bigint DEFAULT nextval('public.users_usr_id_seq'::regclass) NOT NULL,
-    usr_email character varying(64),
-    usr_neptun character varying,
-    usr_firstname text NOT NULL,
-    usr_lastname text NOT NULL,
-    usr_nickname text,
-    usr_svie_member_type character varying(255) DEFAULT 'NEMTAG'::character varying NOT NULL,
-    usr_svie_primary_membership bigint,
-    usr_delegated boolean DEFAULT false NOT NULL,
-    usr_show_recommended_photo boolean DEFAULT false NOT NULL,
-    usr_screen_name character varying(50) NOT NULL,
-    usr_date_of_birth date,
-    usr_gender character varying(50) DEFAULT 'NOTSPECIFIED'::character varying NOT NULL,
-    usr_student_status character varying(50) DEFAULT 'UNKNOWN'::character varying NOT NULL,
-    usr_mother_name character varying(100),
-    usr_photo_path character varying(255),
-    usr_webpage character varying(255),
-    usr_cell_phone character varying(50),
-    usr_home_address character varying(255),
-    usr_est_grad character varying(10),
-    usr_dormitory character varying(50),
-    usr_room character varying(255),
-    usr_status character varying(8) DEFAULT 'INACTIVE'::character varying NOT NULL,
-    usr_password character varying(28),
-    usr_salt character varying(12),
-    usr_lastlogin timestamp without time zone,
-    usr_auth_sch_id character varying,
-    usr_bme_id character varying,
+    id bigint DEFAULT nextval('public.users_usr_id_seq'::regclass) NOT NULL,
+    email character varying(64),
+    neptun character varying,
+    firstname text NOT NULL,
+    lastname text NOT NULL,
+    nickname text,
+    svie_member_type character varying(255) DEFAULT 'NEMTAG'::character varying NOT NULL,
+    svie_primary_membership bigint,
+    delegated boolean DEFAULT false NOT NULL,
+    show_recommended_photo boolean DEFAULT false NOT NULL,
+    screen_name character varying(50) NOT NULL,
+    date_of_birth date,
+    gender character varying(50) DEFAULT 'NOTSPECIFIED'::character varying NOT NULL,
+    student_status character varying(50) DEFAULT 'UNKNOWN'::character varying NOT NULL,
+    mother_name character varying(100),
+    photo_path character varying(255),
+    webpage character varying(255),
+    cell_phone character varying(50),
+    home_address character varying(255),
+    est_grad character varying(10),
+    dormitory character varying(50),
+    room character varying(255),
+    status character varying(8) DEFAULT 'INACTIVE'::character varying NOT NULL,
+    password character varying(28),
+    salt character varying(12),
+    last_login timestamp without time zone,
+    auth_sch_id character varying,
+    bme_id character varying,
     usr_created_at timestamp without time zone,
-    usr_metascore integer,
-    usr_place_of_birth character varying,
-    usr_birth_name character varying
-);
-
-
---
--- Name: usr_private_attrs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.usr_private_attrs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-SET default_with_oids = false;
-
---
--- Name: usr_private_attrs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.usr_private_attrs (
-    id bigint DEFAULT nextval('public.usr_private_attrs_id_seq'::regclass) NOT NULL,
-    usr_id bigint NOT NULL,
-    attr_name character varying(64) NOT NULL,
-    visible boolean DEFAULT false NOT NULL
+    metascore integer,
+    place_of_birth character varying,
+    birth_name character varying
 );
 
 
@@ -718,27 +697,35 @@ ALTER TABLE ONLY public.view_settings ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- Name: belepoigenyles belepoigenyles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.belepoigenyles
-    ADD CONSTRAINT belepoigenyles_pkey PRIMARY KEY (id);
-
-
---
--- Name: ertekeles_uzenet ertekeles_uzenet_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ertekeles_uzenet
-    ADD CONSTRAINT ertekeles_uzenet_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --
--- Name: ertekelesek ertekelesek_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: entry_requests entry_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ertekelesek
-    ADD CONSTRAINT ertekelesek_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.entry_requests
+    ADD CONSTRAINT entry_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evaluation_messages evaluation_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_messages
+    ADD CONSTRAINT evaluation_messages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evaluations evaluations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluations
+    ADD CONSTRAINT evaluations_pkey PRIMARY KEY (id);
 
 
 --
@@ -746,14 +733,14 @@ ALTER TABLE ONLY public.ertekelesek
 --
 
 ALTER TABLE ONLY public.groups
-    ADD CONSTRAINT groups_pkey PRIMARY KEY (grp_id);
+    ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
 
 
 --
--- Name: grp_membership grp_membership_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: memberships grp_membership_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.grp_membership
+ALTER TABLE ONLY public.memberships
     ADD CONSTRAINT grp_membership_pkey PRIMARY KEY (id);
 
 
@@ -806,35 +793,35 @@ ALTER TABLE ONLY public.point_details
 
 
 --
--- Name: point_history point_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: point_histories point_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.point_history
+ALTER TABLE ONLY public.point_histories
     ADD CONSTRAINT point_history_pkey PRIMARY KEY (id);
 
 
 --
--- Name: pontigenyles pontigenyles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: point_requests point_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pontigenyles
-    ADD CONSTRAINT pontigenyles_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.point_requests
+    ADD CONSTRAINT point_requests_pkey PRIMARY KEY (id);
 
 
 --
--- Name: poszt poszt_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: posts poszt_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.poszt
+ALTER TABLE ONLY public.posts
     ADD CONSTRAINT poszt_pkey PRIMARY KEY (id);
 
 
 --
--- Name: poszttipus poszttipus_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: post_types poszttipus_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.poszttipus
-    ADD CONSTRAINT poszttipus_pkey PRIMARY KEY (pttip_id);
+ALTER TABLE ONLY public.post_types
+    ADD CONSTRAINT poszttipus_pkey PRIMARY KEY (id);
 
 
 --
@@ -843,6 +830,14 @@ ALTER TABLE ONLY public.poszttipus
 
 ALTER TABLE ONLY public.principles
     ADD CONSTRAINT principles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: privacies privacies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.privacies
+    ADD CONSTRAINT privacies_pkey PRIMARY KEY (id);
 
 
 --
@@ -862,19 +857,19 @@ ALTER TABLE ONLY public.svie_post_requests
 
 
 --
--- Name: system_attrs system_attrs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: system_attributes system_attrs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.system_attrs
-    ADD CONSTRAINT system_attrs_pkey PRIMARY KEY (attributeid);
+ALTER TABLE ONLY public.system_attributes
+    ADD CONSTRAINT system_attrs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: grp_membership unique_memberships; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: memberships unique_memberships; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.grp_membership
-    ADD CONSTRAINT unique_memberships UNIQUE (grp_id, usr_id);
+ALTER TABLE ONLY public.memberships
+    ADD CONSTRAINT unique_memberships UNIQUE (group_id, user_id);
 
 
 --
@@ -882,7 +877,7 @@ ALTER TABLE ONLY public.grp_membership
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (usr_id);
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
 --
@@ -890,7 +885,7 @@ ALTER TABLE ONLY public.users
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_usr_auth_sch_id_key UNIQUE (usr_auth_sch_id);
+    ADD CONSTRAINT users_usr_auth_sch_id_key UNIQUE (auth_sch_id);
 
 
 --
@@ -898,7 +893,7 @@ ALTER TABLE ONLY public.users
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_usr_bme_id_key UNIQUE (usr_bme_id);
+    ADD CONSTRAINT users_usr_bme_id_key UNIQUE (bme_id);
 
 
 --
@@ -906,7 +901,7 @@ ALTER TABLE ONLY public.users
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_usr_neptun_key UNIQUE (usr_neptun);
+    ADD CONSTRAINT users_usr_neptun_key UNIQUE (neptun);
 
 
 --
@@ -914,15 +909,7 @@ ALTER TABLE ONLY public.users
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_usr_screen_name_key UNIQUE (usr_screen_name);
-
-
---
--- Name: usr_private_attrs usr_private_attrs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.usr_private_attrs
-    ADD CONSTRAINT usr_private_attrs_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT users_usr_screen_name_key UNIQUE (screen_name);
 
 
 --
@@ -937,42 +924,42 @@ ALTER TABLE ONLY public.view_settings
 -- Name: bel_tipus_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX bel_tipus_idx ON public.belepoigenyles USING btree (belepo_tipus);
+CREATE INDEX bel_tipus_idx ON public.entry_requests USING btree (entry_type);
 
 
 --
 -- Name: ert_semester_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ert_semester_idx ON public.ertekelesek USING btree (semester);
+CREATE INDEX ert_semester_idx ON public.evaluations USING btree (semester);
 
 
 --
 -- Name: fki_felado_usr_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fki_felado_usr_id ON public.ertekeles_uzenet USING btree (felado_usr_id);
+CREATE INDEX fki_felado_usr_id ON public.evaluation_messages USING btree (sender_user_id);
 
 
 --
 -- Name: fki_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fki_group_id ON public.ertekeles_uzenet USING btree (group_id);
+CREATE INDEX fki_group_id ON public.evaluation_messages USING btree (group_id);
 
 
 --
 -- Name: groups_grp_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX groups_grp_id_idx ON public.groups USING btree (grp_id);
+CREATE UNIQUE INDEX groups_grp_id_idx ON public.groups USING btree (id);
 
 
 --
 -- Name: idx_groups_grp_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_groups_grp_name ON public.groups USING btree (grp_name);
+CREATE INDEX idx_groups_grp_name ON public.groups USING btree (name);
 
 
 --
@@ -1000,28 +987,28 @@ CREATE INDEX index_point_detail_comments_on_user_id ON public.point_detail_comme
 -- Name: membership_usr_fk_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX membership_usr_fk_idx ON public.grp_membership USING btree (usr_id);
+CREATE INDEX membership_usr_fk_idx ON public.memberships USING btree (user_id);
 
 
 --
 -- Name: next_version_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX next_version_idx ON public.ertekelesek USING btree (next_version NULLS FIRST);
+CREATE INDEX next_version_idx ON public.evaluations USING btree (next_version NULLS FIRST);
 
 
 --
 -- Name: poszt_fk_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX poszt_fk_idx ON public.poszt USING btree (grp_member_id);
+CREATE INDEX poszt_fk_idx ON public.posts USING btree (membership_id);
 
 
 --
 -- Name: unique_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX unique_idx ON public.ertekelesek USING btree (grp_id, semester, next_version NULLS FIRST);
+CREATE UNIQUE INDEX unique_idx ON public.evaluations USING btree (group_id, semester, next_version NULLS FIRST);
 
 
 --
@@ -1035,21 +1022,21 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 -- Name: users_usr_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX users_usr_id_idx ON public.users USING btree (usr_id);
+CREATE UNIQUE INDEX users_usr_id_idx ON public.users USING btree (id);
 
 
 --
 -- Name: users_usr_neptun_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX users_usr_neptun_idx ON public.users USING btree (upper((usr_neptun)::text));
+CREATE UNIQUE INDEX users_usr_neptun_idx ON public.users USING btree (upper((neptun)::text));
 
 
 --
 -- Name: users_usr_screen_name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX users_usr_screen_name_idx ON public.users USING btree (upper((usr_screen_name)::text));
+CREATE UNIQUE INDEX users_usr_screen_name_idx ON public.users USING btree (upper((screen_name)::text));
 
 
 --
@@ -1057,7 +1044,7 @@ CREATE UNIQUE INDEX users_usr_screen_name_idx ON public.users USING btree (upper
 --
 
 ALTER TABLE ONLY public.groups
-    ADD CONSTRAINT "$1" FOREIGN KEY (grp_parent) REFERENCES public.groups(grp_id) ON UPDATE CASCADE ON DELETE SET NULL;
+    ADD CONSTRAINT "$1" FOREIGN KEY (parent_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE SET NULL;
 
 
 --
@@ -1065,79 +1052,79 @@ ALTER TABLE ONLY public.groups
 --
 
 ALTER TABLE ONLY public.lostpw_tokens
-    ADD CONSTRAINT fk1e9df02e5854b081 FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
+    ADD CONSTRAINT fk1e9df02e5854b081 FOREIGN KEY (usr_id) REFERENCES public.users(id);
 
 
 --
--- Name: belepoigenyles fk4e301ac36958e716; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: entry_requests fk4e301ac36958e716; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.belepoigenyles
-    ADD CONSTRAINT fk4e301ac36958e716 FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
-
-
---
--- Name: ertekelesek fk807db18871c0d156; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ertekelesek
-    ADD CONSTRAINT fk807db18871c0d156 FOREIGN KEY (felado_usr_id) REFERENCES public.users(usr_id);
+ALTER TABLE ONLY public.entry_requests
+    ADD CONSTRAINT fk4e301ac36958e716 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: ertekelesek fk807db18879696582; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: evaluations fk807db18871c0d156; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ertekelesek
-    ADD CONSTRAINT fk807db18879696582 FOREIGN KEY (grp_id) REFERENCES public.groups(grp_id);
-
-
---
--- Name: ertekelesek fk807db188b31cf015; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ertekelesek
-    ADD CONSTRAINT fk807db188b31cf015 FOREIGN KEY (elbiralo_usr_id) REFERENCES public.users(usr_id);
+ALTER TABLE ONLY public.evaluations
+    ADD CONSTRAINT fk807db18871c0d156 FOREIGN KEY (creator_user_id) REFERENCES public.users(id);
 
 
 --
--- Name: belepoigenyles fk_ertekeles_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: evaluations fk807db18879696582; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.belepoigenyles
-    ADD CONSTRAINT fk_ertekeles_id FOREIGN KEY (ertekeles_id) REFERENCES public.ertekelesek(id) ON DELETE CASCADE;
-
-
---
--- Name: pontigenyles fk_ertekeles_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pontigenyles
-    ADD CONSTRAINT fk_ertekeles_id FOREIGN KEY (ertekeles_id) REFERENCES public.ertekelesek(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.evaluations
+    ADD CONSTRAINT fk807db18879696582 FOREIGN KEY (group_id) REFERENCES public.groups(id);
 
 
 --
--- Name: ertekeles_uzenet fk_felado_usr_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: evaluations fk807db188b31cf015; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ertekeles_uzenet
-    ADD CONSTRAINT fk_felado_usr_id FOREIGN KEY (felado_usr_id) REFERENCES public.users(usr_id) ON DELETE SET NULL;
-
-
---
--- Name: ertekeles_uzenet fk_group_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.ertekeles_uzenet
-    ADD CONSTRAINT fk_group_id FOREIGN KEY (group_id) REFERENCES public.groups(grp_id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.evaluations
+    ADD CONSTRAINT fk807db188b31cf015 FOREIGN KEY (reviewer_user_id) REFERENCES public.users(id);
 
 
 --
--- Name: ertekelesek fk_next_version; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: entry_requests fk_ertekeles_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ertekelesek
-    ADD CONSTRAINT fk_next_version FOREIGN KEY (next_version) REFERENCES public.ertekelesek(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.entry_requests
+    ADD CONSTRAINT fk_ertekeles_id FOREIGN KEY (evaluation_id) REFERENCES public.evaluations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: point_requests fk_ertekeles_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.point_requests
+    ADD CONSTRAINT fk_ertekeles_id FOREIGN KEY (evaluation_id) REFERENCES public.evaluations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: evaluation_messages fk_felado_usr_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_messages
+    ADD CONSTRAINT fk_felado_usr_id FOREIGN KEY (sender_user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: evaluation_messages fk_group_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_messages
+    ADD CONSTRAINT fk_group_id FOREIGN KEY (group_id) REFERENCES public.groups(id) ON DELETE CASCADE;
+
+
+--
+-- Name: evaluations fk_next_version; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluations
+    ADD CONSTRAINT fk_next_version FOREIGN KEY (next_version) REFERENCES public.evaluations(id) ON DELETE SET NULL;
 
 
 --
@@ -1153,7 +1140,7 @@ ALTER TABLE ONLY public.point_detail_comments
 --
 
 ALTER TABLE ONLY public.view_settings
-    ADD CONSTRAINT fk_rails_2450b9d422 FOREIGN KEY (user_id) REFERENCES public.users(usr_id);
+    ADD CONSTRAINT fk_rails_2450b9d422 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -1161,7 +1148,7 @@ ALTER TABLE ONLY public.view_settings
 --
 
 ALTER TABLE ONLY public.point_details
-    ADD CONSTRAINT fk_rails_6ef8df1bae FOREIGN KEY (point_request_id) REFERENCES public.pontigenyles(id);
+    ADD CONSTRAINT fk_rails_6ef8df1bae FOREIGN KEY (point_request_id) REFERENCES public.point_requests(id);
 
 
 --
@@ -1169,7 +1156,7 @@ ALTER TABLE ONLY public.point_details
 --
 
 ALTER TABLE ONLY public.principles
-    ADD CONSTRAINT fk_rails_84e8865fd0 FOREIGN KEY (evaluation_id) REFERENCES public.ertekelesek(id);
+    ADD CONSTRAINT fk_rails_84e8865fd0 FOREIGN KEY (evaluation_id) REFERENCES public.evaluations(id);
 
 
 --
@@ -1185,31 +1172,31 @@ ALTER TABLE ONLY public.point_details
 --
 
 ALTER TABLE ONLY public.point_detail_comments
-    ADD CONSTRAINT fk_rails_fd72f0d605 FOREIGN KEY (user_id) REFERENCES public.users(usr_id);
+    ADD CONSTRAINT fk_rails_fd72f0d605 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: pontigenyles fkaa1034cd6958e716; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: point_requests fkaa1034cd6958e716; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pontigenyles
-    ADD CONSTRAINT fkaa1034cd6958e716 FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
-
-
---
--- Name: grp_membership grp_membership_grp_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.grp_membership
-    ADD CONSTRAINT grp_membership_grp_id_fkey FOREIGN KEY (grp_id) REFERENCES public.groups(grp_id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY public.point_requests
+    ADD CONSTRAINT fkaa1034cd6958e716 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: grp_membership grp_membership_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: memberships grp_membership_grp_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.grp_membership
-    ADD CONSTRAINT grp_membership_usr_id_fkey FOREIGN KEY (usr_id) REFERENCES public.users(usr_id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY public.memberships
+    ADD CONSTRAINT grp_membership_grp_id_fkey FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: memberships grp_membership_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.memberships
+    ADD CONSTRAINT grp_membership_usr_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1217,7 +1204,7 @@ ALTER TABLE ONLY public.grp_membership
 --
 
 ALTER TABLE ONLY public.im_accounts
-    ADD CONSTRAINT im_accounts_usr_id_fkey FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
+    ADD CONSTRAINT im_accounts_usr_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -1225,7 +1212,7 @@ ALTER TABLE ONLY public.im_accounts
 --
 
 ALTER TABLE ONLY public.log
-    ADD CONSTRAINT log_group FOREIGN KEY (grp_id) REFERENCES public.groups(grp_id) ON UPDATE CASCADE ON DELETE CASCADE;
+    ADD CONSTRAINT log_group FOREIGN KEY (grp_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1233,39 +1220,39 @@ ALTER TABLE ONLY public.log
 --
 
 ALTER TABLE ONLY public.log
-    ADD CONSTRAINT log_user FOREIGN KEY (usr_id) REFERENCES public.users(usr_id) ON UPDATE CASCADE ON DELETE CASCADE;
+    ADD CONSTRAINT log_user FOREIGN KEY (usr_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
--- Name: point_history point_history_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: point_histories point_history_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.point_history
-    ADD CONSTRAINT point_history_usr_id_fkey FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
-
-
---
--- Name: poszt poszt_grp_member_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.poszt
-    ADD CONSTRAINT poszt_grp_member_fk FOREIGN KEY (grp_member_id) REFERENCES public.grp_membership(id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY public.point_histories
+    ADD CONSTRAINT point_history_usr_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: poszt poszt_pttip_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: posts poszt_grp_member_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.poszt
-    ADD CONSTRAINT poszt_pttip_fk FOREIGN KEY (pttip_id) REFERENCES public.poszttipus(pttip_id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT poszt_grp_member_fk FOREIGN KEY (membership_id) REFERENCES public.memberships(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
--- Name: poszttipus poszttipus_opc_csoport; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: posts poszt_pttip_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.poszttipus
-    ADD CONSTRAINT poszttipus_opc_csoport FOREIGN KEY (grp_id) REFERENCES public.groups(grp_id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT poszt_pttip_fk FOREIGN KEY (post_type_id) REFERENCES public.post_types(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: post_types poszttipus_opc_csoport; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_types
+    ADD CONSTRAINT poszttipus_opc_csoport FOREIGN KEY (group_id) REFERENCES public.groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1273,15 +1260,15 @@ ALTER TABLE ONLY public.poszttipus
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_main_group_fkey FOREIGN KEY (usr_svie_primary_membership) REFERENCES public.grp_membership(id);
+    ADD CONSTRAINT users_main_group_fkey FOREIGN KEY (svie_primary_membership) REFERENCES public.memberships(id);
 
 
 --
--- Name: usr_private_attrs usr_private_attrs_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: privacies usr_private_attrs_usr_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.usr_private_attrs
-    ADD CONSTRAINT usr_private_attrs_usr_id_fkey FOREIGN KEY (usr_id) REFERENCES public.users(usr_id);
+ALTER TABLE ONLY public.privacies
+    ADD CONSTRAINT usr_private_attrs_usr_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -1290,33 +1277,22 @@ ALTER TABLE ONLY public.usr_private_attrs
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161124163851');
+INSERT INTO "schema_migrations" (version) VALUES
+('20161124163851'),
+('20171130184224'),
+('20180315103617'),
+('20180317194014'),
+('20180317200507'),
+('20180403171730'),
+('20180501175635'),
+('20180505152100'),
+('20180617081041'),
+('20180705121831'),
+('20180730191308'),
+('20181112160701'),
+('20181220204207'),
+('20190106175754'),
+('20191025190035'),
+('20200127202810');
 
-INSERT INTO schema_migrations (version) VALUES ('20171130184224');
-
-INSERT INTO schema_migrations (version) VALUES ('20180315103617');
-
-INSERT INTO schema_migrations (version) VALUES ('20180317194014');
-
-INSERT INTO schema_migrations (version) VALUES ('20180317200507');
-
-INSERT INTO schema_migrations (version) VALUES ('20180403171730');
-
-INSERT INTO schema_migrations (version) VALUES ('20180501175635');
-
-INSERT INTO schema_migrations (version) VALUES ('20180505152100');
-
-INSERT INTO schema_migrations (version) VALUES ('20180617081041');
-
-INSERT INTO schema_migrations (version) VALUES ('20180705121831');
-
-INSERT INTO schema_migrations (version) VALUES ('20180730191308');
-
-INSERT INTO schema_migrations (version) VALUES ('20181112160701');
-
-INSERT INTO schema_migrations (version) VALUES ('20181220204207');
-
-INSERT INTO schema_migrations (version) VALUES ('20190106175754');
-
-INSERT INTO schema_migrations (version) VALUES ('20191025190035');
 

--- a/test/controllers/auth_sch_services_controller_test.rb
+++ b/test/controllers/auth_sch_services_controller_test.rb
@@ -46,7 +46,7 @@ class AuthSchServicesControllerTest < ActionDispatch::IntegrationTest
     expected_response = [
       {
         'start' => '2010-02-02',
-        'end' => grp_membership(:babhamozo_member_into_group).end_date,
+        'end' => membership(:babhamozo_member_into_group).end_date,
         'group_name' => groups(:babhamozo).name,
         'group_id' => groups(:babhamozo).id,
         'posts' => ['tag']

--- a/test/controllers/membership_controller_test.rb
+++ b/test/controllers/membership_controller_test.rb
@@ -33,7 +33,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'archive active_member of group' do
-    membership = grp_membership(:newbie_membership)
+    membership = membership(:newbie_membership)
     Timecop.freeze do
       put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/archive", xhr: true
 
@@ -43,7 +43,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'archive inactive_member of group' do
-    membership = grp_membership(:inactive_babhamozo_member)
+    membership = membership(:inactive_babhamozo_member)
     Timecop.freeze do
       put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/archive", xhr: true
 
@@ -53,7 +53,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'unarchive active_member of group with group leader' do
-    membership = grp_membership(:active_archived_babhamozo_member)
+    membership = membership(:active_archived_babhamozo_member)
 
     put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/unarchive", xhr: true
 
@@ -61,7 +61,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'unarchive inactive_member of group with group leader' do
-    membership = grp_membership(:inactive_archived_babhamozo_member)
+    membership = membership(:inactive_archived_babhamozo_member)
 
     put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/unarchive", xhr: true
 
@@ -70,7 +70,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
 
   test 'unarchive active_member of group' do
     login_as_user(:pek_admin)
-    membership = grp_membership(:active_archived_babhamozo_member)
+    membership = membership(:active_archived_babhamozo_member)
 
     put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/unarchive", xhr: true
 
@@ -79,7 +79,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
 
   test 'unarchive inactive_member of group' do
     login_as_user(:pek_admin)
-    membership = grp_membership(:inactive_archived_babhamozo_member)
+    membership = membership(:inactive_archived_babhamozo_member)
 
     put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/unarchive", xhr: true
 
@@ -88,32 +88,32 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
 
   test 'forbidden archive of member' do
     login_as_user(:non_babhamozo_member)
-    membership = grp_membership(:babhamozo_leader_into_group)
+    membership = membership(:babhamozo_leader_into_group)
     put "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/unarchive", xhr: true
 
     assert_response :forbidden
   end
 
   test 'inactivation of a group member' do
-    membership = grp_membership(:babhamozo_member_into_group)
+    membership = membership(:babhamozo_member_into_group)
     Timecop.freeze do
       post "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/inactivate", xhr: true
 
-      assert membership.reload.membership_end.today?
+      assert membership.reload.end_date.today?
     end
     assert_response :success
   end
 
   test 'reactivation of an inactive member' do
-    membership = grp_membership(:inactive_babhamozo_member)
+    membership = membership(:inactive_babhamozo_member)
     post "/groups/#{groups(:babhamozo).id}/memberships/#{membership.id}/reactivate", xhr: true
 
-    assert_nil membership.reload.membership_end
+    assert_nil membership.reload.end_date
     assert_response :success
   end
 
   test 'delegation became false when inactivate a group member who delegated that group' do
-    membership = grp_membership(:babhamozo_member_who_delegated)
+    membership = membership(:babhamozo_member_who_delegated)
 
     assert membership.user.delegated
     assert_equal(membership.user.primary_membership, membership)

--- a/test/controllers/svie_controller_test.rb
+++ b/test/controllers/svie_controller_test.rb
@@ -10,16 +10,16 @@ class SvieControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal 3, assigns(:svie_memberships).size
-    assert_equal grp_membership(:user_with_primary_membership).id,
+    assert_equal membership(:user_with_primary_membership).id,
                  assigns(:svie_memberships).first.id
-    assert_equal grp_membership(:newbie_membership).id, assigns(:svie_memberships).last.id
+    assert_equal membership(:newbie_membership).id, assigns(:svie_memberships).last.id
   end
 
   test 'save change of primary group' do
-    post '/svie/update', svie: { primary_membership: grp_membership(:not_primary_membership).id }
+    post '/svie/update', svie: { primary_membership: membership(:not_primary_membership).id }
 
     assert_redirected_to profiles_me_path
-    assert_equal grp_membership(:not_primary_membership).id,
+    assert_equal membership(:not_primary_membership).id,
                  users(:user_with_primary_membership).reload.svie_primary_membership
   end
 end

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :membership do
     association :user
     association :group
-    membership_start { '2010-02-02' }
+    start_date { '2010-02-02' }
 
     trait :leader do
       posts { create_list(:post, 1, :leader) }

--- a/test/fixtures/entry_requests.yml
+++ b/test/fixtures/entry_requests.yml
@@ -1,6 +1,6 @@
 babhamozo_member_2018:
   id: 10
-  belepo_tipus: KB
-  szoveges_ertekeles: Nagyon jó srác
-  ertekeles_id: 1
-  usr_id: 4002
+  entry_type: KB
+  justification: Nagyon jó srác
+  evaluation_id: 1
+  user_id: 4002

--- a/test/fixtures/evaluations.yml
+++ b/test/fixtures/evaluations.yml
@@ -1,41 +1,41 @@
 babhamozo_2018:
   id: 1
-  belepoigeny_statusz: ELFOGADVA
-  feladas: 2018-01-02
-  pontigeny_statusz: ELFOGADVA
+  entry_request_status: ELFOGADVA
+  timestamp: 2018-01-02
+  point_request_status: ELFOGADVA
   semester: 201720181
-  szoveges_ertekeles: Lyo lesz
-  utolso_elbiralas: 2018-01-20
-  utolso_modositas: 2018-01-03
-  elbiralo_usr_id: 6001
-  grp_id: 1
-  felado_usr_id: 4001
-  pontozasi_elvek: Aki dolgozik az kap pontot
+  justification: Lyo lesz
+  last_evaulation: 2018-01-20
+  last_modification: 2018-01-03
+  reviewer_user_id: 6001
+  group_id: 1
+  creator_user_id: 4001
+  explanation: Aki dolgozik az kap pontot
 
 babhamozo_2018_2:
   id: 2
-  belepoigeny_statusz: ELFOGADVA
-  feladas: 2018-06-02
-  pontigeny_statusz: ELFOGADVA
+  entry_request_status: ELFOGADVA
+  timestamp: 2018-06-02
+  point_request_status: ELFOGADVA
   semester: 201720182
-  szoveges_ertekeles: Lyo lesz
-  utolso_elbiralas: 2018-06-20
-  utolso_modositas: 2018-07-03
-  elbiralo_usr_id: 6001
-  grp_id: 1
-  felado_usr_id: 4001
-  pontozasi_elvek: Aki dolgozik az kap pontot
+  justification: Lyo lesz
+  last_evaulation: 2018-06-20
+  last_modification: 2018-07-03
+  reviewer_user_id: 6001
+  group_id: 1
+  creator_user_id: 4001
+  explanation: Aki dolgozik az kap pontot
 
 kir_dev_2018_2:
   id: 3
-  belepoigeny_statusz: ELFOGADVA
-  feladas: 2018-06-02
-  pontigeny_statusz: ELFOGADVA
+  entry_request_status: ELFOGADVA
+  timestamp: 2018-06-02
+  point_request_status: ELFOGADVA
   semester: 201720182
-  szoveges_ertekeles: Lyo lesz
-  utolso_elbiralas: 2018-06-20
-  utolso_modositas: 2018-07-03
-  elbiralo_usr_id: 6001
-  grp_id: 106
-  felado_usr_id: 4001
-  pontozasi_elvek: Aki dolgozik az kap pontot
+  justification: Lyo lesz
+  last_evaulation: 2018-06-20
+  last_modification: 2018-07-03
+  reviewer_user_id: 6001
+  group_id: 106
+  creator_user_id: 4001
+  explanation: Aki dolgozik az kap pontot

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,60 +1,60 @@
 parent:
-  grp_id: 369
-  grp_name: SVIE
-  grp_type: :team
+  id: 369
+  name: SVIE
+  type: :team
 
 babhamozo:
-  grp_id: 1
-  grp_name: Babhámozó
-  grp_type: szakmai kör
-  grp_parent: 369
-  grp_state: active
-  grp_description: vietnámiak
-  grp_webpage: http://babhamozo.sch.bme.hu
-  grp_maillist: babhamozo@sch.bme.hu
-  grp_head: főhámozó
-  grp_founded: 1998
-  grp_issvie: true
-  grp_svie_delegate_nr: 2
-  grp_users_can_apply: true
+  id: 1
+  name: Babhámozó
+  type: szakmai kör
+  parent_id: 369
+  state: active
+  description: vietnámiak
+  webpage: http://babhamozo.sch.bme.hu
+  maillist: babhamozo@sch.bme.hu
+  head: főhámozó
+  founded: 1998
+  issvie: true
+  delegate_count: 2
+  users_can_apply: true
 
 <% 40.times do |i| %>
 group<%= i %>:
-  grp_id: <%= "2#{i}" %>
-  grp_name: group<% i %>
-  grp_type: :group
+  id: <%= "2#{i}" %>
+  name: group<% i %>
+  type: :group
 <% end %>
 
 svie_group:
-  grp_id: 3
-  grp_name: Pizzás
-  grp_type: :group
-  grp_issvie: true
+  id: 3
+  name: Pizzás
+  type: :group
+  issvie: true
 
 svie_group_with_newbies:
-  grp_id: 4
-  grp_name: Hambis
-  grp_type: :group
-  grp_issvie: true
+  id: 4
+  name: Hambis
+  type: :group
+  issvie: true
 
 rvt:
-  grp_id: 146
-  grp_name: RVT
-  grp_type: :team
-  grp_issvie: false
+  id: 146
+  name: RVT
+  type: :team
+  issvie: false
 
 kir_dev:
-  grp_id: 106
-  grp_name: Kir-Dev
-  grp_type: :group
-  grp_issvie: true
+  id: 106
+  name: Kir-Dev
+  type: :group
+  issvie: true
 
 group_with_no_evaluation:
-  grp_id: 300
-  grp_name: Nincs értékelés
-  grp_type: :group
+  id: 300
+  name: Nincs értékelés
+  type: :group
 
 group_with_existing_evaluation:
-  grp_id: 301
-  grp_name: Értékes kör
-  grp_type: :group
+  id: 301
+  name: Értékes kör
+  type: :group

--- a/test/fixtures/membership.yml
+++ b/test/fixtures/membership.yml
@@ -1,79 +1,79 @@
 babhamozo_leader_into_group:
   id: 1
-  grp_id: 1
-  usr_id: 4001
+  group_id: 1
+  user_id: 4001
 
 babhamozo_member_into_group:
   id: 2
-  grp_id: 1
-  usr_id: 4002
-  membership_start: 2010-02-02
+  group_id: 1
+  user_id: 4002
+  start_date: 2010-02-02
 
 inactive_babhamozo_member:
   id: 3
-  grp_id: 1
-  usr_id: 4004
-  membership_end: <%= Time.now %>
+  group_id: 1
+  user_id: 4004
+  end_date: <%= Time.now %>
 
 user_with_primary_membership:
   id: 4
-  grp_id: 1
-  usr_id: 5000
+  group_id: 1
+  user_id: 5000
 
 not_primary_membership:
   id: 5
-  grp_id: 3
-  usr_id: 5000
+  group_id: 3
+  user_id: 5000
 
 non_svie_membership:
   id: 6
-  grp_id: 22
-  usr_id: 5000
+  group_id: 22
+  user_id: 5000
 
 newbie_membership:
   id: 7
-  grp_id: 4
-  usr_id: 5000
+  group_id: 4
+  user_id: 5000
 
 babhamozo_member_who_delegated:
   id: 8
-  grp_id: 1
-  usr_id: 4005
+  group_id: 1
+  user_id: 4005
 
 inactive_archived_babhamozo_member:
   id: 10
-  grp_id: 1
-  usr_id: 5005
+  group_id: 1
+  user_id: 5005
   archived: <%= Time.now %>
-  membership_end: <%= Time.now %>
+  end_date: <%= Time.now %>
 
 active_archived_babhamozo_member:
   id: 11
-  grp_id: 1
-  usr_id: 5006
+  group_id: 1
+  user_id: 5006
   archived: <%= Time.now %>
 
 babhamozo_member_who_delegated:
   id: 8
-  grp_id: 1
-  usr_id: 4005
+  group_id: 1
+  user_id: 4005
 
 rvt_membership:
   id: 9
-  grp_id: 146
-  usr_id: 6001
+  group_id: 146
+  user_id: 6001
 
 pek_admin_membership:
   id: 12
-  grp_id: 106
-  usr_id: 7000
+  group_id: 106
+  user_id: 7000
 
 evaluation_giver_group1:
   id: 14
-  usr_id: 8000
-  grp_id: 300
+  user_id: 8000
+  group_id: 300
 
 evaluation_giver_group2:
   id: 15
-  usr_id: 8000
-  grp_id: 301
+  user_id: 8000
+  group_id: 301

--- a/test/fixtures/point_request.yml
+++ b/test/fixtures/point_request.yml
@@ -1,17 +1,17 @@
 babhamozo_leader_point_request_2018_1:
   id: 1
-  usr_id: 4001
-  ertekeles_id: 1
-  pont: 50
+  user_id: 4001
+  evaluation_id: 1
+  point: 50
 
 babhamozo_leader_point_request_2018_2:
   id: 2
-  usr_id: 4001
-  ertekeles_id: 2
-  pont: 50
+  user_id: 4001
+  evaluation_id: 2
+  point: 50
 
 babhamozo_leader_point_request_for_kir_dev_2018_2:
   id: 3
-  usr_id: 4001
-  ertekeles_id: 3
-  pont: 50
+  user_id: 4001
+  evaluation_id: 3
+  point: 50

--- a/test/fixtures/post.yml
+++ b/test/fixtures/post.yml
@@ -1,19 +1,19 @@
 babhamozo_leader:
-  grp_member_id: 1
-  pttip_id: 3
+  membership_id: 1
+  post_type_id: 3
 
 newbie_in_svie_group:
-  grp_member_id: 7
-  pttip_id: 6
+  membership_id: 7
+  post_type_id: 6
 
 pek_admin_in_kir_dev:
-  grp_member_id: 12
-  pttip_id: 66
+  membership_id: 12
+  post_type_id: 66
 
 evaluation_giver_to_leader1:
-  grp_member_id: 14
-  pttip_id: 3
+  membership_id: 14
+  post_type_id: 3
 
 evaluation_giver_to_leader2:
-  grp_member_id: 15
-  pttip_id: 3
+  membership_id: 15
+  post_type_id: 3

--- a/test/fixtures/post_type.yml
+++ b/test/fixtures/post_type.yml
@@ -1,15 +1,15 @@
 leader:
-  pttip_id: 3
-  pttip_name: körvezető
+  id: 3
+  name: körvezető
 
 newbie:
-  pttip_id: 6
-  pttip_name: feldolgozás alatt
+  id: 6
+  name: feldolgozás alatt
 
 pek_admin:
-  pttip_id: 66
-  pttip_name: PéK Admin
+  id: 66
+  name: PéK Admin
 
 new_member:
-  pttip_id: 104
-  pttip_name: újonc
+  id: 104
+  name: újonc

--- a/test/fixtures/system_attributes.yml
+++ b/test/fixtures/system_attributes.yml
@@ -1,11 +1,11 @@
 semester:
-  attributename: szemeszter
-  attributevalue: 200820091
+  name: szemeszter
+  value: 200820091
 
 app_season:
-  attributename: ertekeles_idoszak
-  attributevalue: NINCSERTEKELES
+  name: ertekeles_idoszak
+  value: NINCSERTEKELES
 
 max_point_for_semester:
-  attributename: max_point_for_semester
-  attributevalue: 100
+  name: max_point_for_semester
+  value: 100

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,139 +1,139 @@
 sanyi:
-  usr_id: 10
-  usr_firstname: Sándor
-  usr_lastname: Hentes
-  usr_nickname: Sanyi
-  usr_screen_name: sanyi92
-  usr_cell_phone: +36201234567
-  usr_auth_sch_id: asdf-asdf-1234
-  usr_neptun: ABC123
-  usr_email: sanyi92@sch.bme.hu
-  usr_metascore: 1000
+  id: 10
+  firstname: Sándor
+  lastname: Hentes
+  nickname: Sanyi
+  screen_name: sanyi92
+  cell_phone: +36201234567
+  auth_sch_id: asdf-asdf-1234
+  neptun: ABC123
+  email: sanyi92@sch.bme.hu
+  metascore: 1000
 
 bela:
-  usr_id: 11
-  usr_firstname: Béla
-  usr_lastname: Kovács
-  usr_nickname: Kovibélus
-  usr_screen_name: kovibelus
-  usr_auth_sch_id: qwer-qwer-5678
-  usr_metascore: 5000
+  id: 11
+  firstname: Béla
+  lastname: Kovács
+  nickname: Kovibélus
+  screen_name: kovibelus
+  auth_sch_id: qwer-qwer-5678
+  metascore: 5000
 
 <% 100.times do |n| %>
 user_<%= n %>:
-  usr_id: <%= "2#{n}" %>
-  usr_firstname: Júzer <%= n %>
-  usr_lastname: Pék
-  usr_nickname: pék <%= n %>
-  usr_screen_name: <%= "pekuser#{n}" %>
-  usr_auth_sch_id: xcvb-xcvb-xcvb-<%= n %>
-  usr_metascore: <%= n %>
+  id: <%= "2#{n}" %>
+  firstname: Júzer <%= n %>
+  lastname: Pék
+  nickname: pék <%= n %>
+  screen_name: <%= "pekuser#{n}" %>
+  auth_sch_id: xcvb-xcvb-xcvb-<%= n %>
+  metascore: <%= n %>
 <% end %>
 
 metascore_1:
-  usr_id: 3000
-  usr_firstname: Béla
-  usr_lastname: Metascore
-  usr_screen_name: metatest
-  usr_auth_sch_id: meta-score-test
-  usr_cell_phone: 06305669234
-  usr_metascore: 0
+  id: 3000
+  firstname: Béla
+  lastname: Metascore
+  screen_name: metatest
+  auth_sch_id: meta-score-test
+  cell_phone: 06305669234
+  metascore: 0
 
 metascore_2:
-  usr_id: 3001
-  usr_firstname: András
-  usr_lastname: Metascore
-  usr_screen_name: metatest2
-  usr_auth_sch_id: meta-score-test-2
-  usr_photo_path: myphoto.jpg
-  usr_email: mail@sch.bme.hu
-  usr_dormitory: Schönherz
-  usr_metascore: 0
+  id: 3001
+  firstname: András
+  lastname: Metascore
+  screen_name: metatest2
+  auth_sch_id: meta-score-test-2
+  photo_path: myphoto.jpg
+  email: mail@sch.bme.hu
+  dormitory: Schönherz
+  metascore: 0
 
 babhamozo_leader:
-  usr_id: 4001
-  usr_firstname: Babhámozó
-  usr_lastname: Vezető
-  usr_screen_name: babham123
-  usr_auth_sch_id: lets-give-this-shit-everywhere-1
+  id: 4001
+  firstname: Babhámozó
+  lastname: Vezető
+  screen_name: babham123
+  auth_sch_id: lets-give-this-shit-everywhere-1
 
 babhamozo_member:
-  usr_id: 4002
-  usr_firstname: Babos
-  usr_lastname: Lajos
-  usr_screen_name: lali
-  usr_auth_sch_id: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+  id: 4002
+  firstname: Babos
+  lastname: Lajos
+  screen_name: lali
+  auth_sch_id: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
 
 non_babhamozo_member:
-  usr_id: 4003
-  usr_firstname: Borsó
-  usr_lastname: Lajos
-  usr_screen_name: bori
-  usr_auth_sch_id: lets-give-this-shit-everywhere-2
+  id: 4003
+  firstname: Borsó
+  lastname: Lajos
+  screen_name: bori
+  auth_sch_id: lets-give-this-shit-everywhere-2
 
 past_babhamozo_member:
-  usr_id: 4004
-  usr_firstname: Öreg
-  usr_lastname: Csilis
-  usr_screen_name: chili
-  usr_auth_sch_id: lets-give-this-shit-everywhere-3
+  id: 4004
+  firstname: Öreg
+  lastname: Csilis
+  screen_name: chili
+  auth_sch_id: lets-give-this-shit-everywhere-3
 
 delegated_babhamozo_member:
-  usr_id: 4005
-  usr_firstname: Delegált
-  usr_lastname: Csilis
-  usr_screen_name: kuldott
-  usr_delegated: true
-  usr_svie_primary_membership: 8
-  usr_auth_sch_id: lets-give-this-shit-everywhere-4
+  id: 4005
+  firstname: Delegált
+  lastname: Csilis
+  screen_name: kuldott
+  delegated: true
+  svie_primary_membership: 8
+  auth_sch_id: lets-give-this-shit-everywhere-4
 
 user_with_primary_membership:
-  usr_id: 5000
-  usr_firstname: GoFor
-  usr_lastname: SVIE
-  usr_screen_name: csakasvie
-  usr_svie_primary_membership: 4
-  usr_svie_member_type: RENDESTAG
-  usr_auth_sch_id: lets-give-this-shit-everywhere-5
+  id: 5000
+  firstname: GoFor
+  lastname: SVIE
+  screen_name: csakasvie
+  svie_primary_membership: 4
+  svie_member_type: RENDESTAG
+  auth_sch_id: lets-give-this-shit-everywhere-5
 
 archived_active_babhamozo_member:
-  usr_id: 5005
-  usr_firstname: Archi
-  usr_lastname: János
-  usr_screen_name: ajani
-  usr_auth_sch_id: lets-give-this-shit-everywhere-6
+  id: 5005
+  firstname: Archi
+  lastname: János
+  screen_name: ajani
+  auth_sch_id: lets-give-this-shit-everywhere-6
 
 archived_inactive__babhamozo_member:
-  usr_id: 5006
-  usr_firstname: Öreg Archi
-  usr_lastname: János
-  usr_screen_name: oldjani
-  usr_auth_sch_id: lets-give-this-shit-everywhere-7
+  id: 5006
+  firstname: Öreg Archi
+  lastname: János
+  screen_name: oldjani
+  auth_sch_id: lets-give-this-shit-everywhere-7
 
 not_rvt_member:
-  usr_id: 6000
-  usr_firstname: Melegvíz
-  usr_lastname: Fogyasztó
-  usr_screen_name: szobanövény
-  usr_auth_sch_id: lets-give-this-shit-everywhere-8
+  id: 6000
+  firstname: Melegvíz
+  lastname: Fogyasztó
+  screen_name: szobanövény
+  auth_sch_id: lets-give-this-shit-everywhere-8
 
 rvt_member:
-  usr_id: 6001
-  usr_firstname: Rvts
-  usr_lastname: Pistike
-  usr_screen_name: pityuka
-  usr_auth_sch_id: lets-give-this-shit-everywhere-9
+  id: 6001
+  firstname: Rvts
+  lastname: Pistike
+  screen_name: pityuka
+  auth_sch_id: lets-give-this-shit-everywhere-9
 
 pek_admin:
-  usr_id: 7000
-  usr_firstname: Kir
-  usr_lastname: Bálint
-  usr_screen_name: kir
-  usr_auth_sch_id: lets-give-this-shit-everywhere-10
+  id: 7000
+  firstname: Kir
+  lastname: Bálint
+  screen_name: kir
+  auth_sch_id: lets-give-this-shit-everywhere-10
 
 evaluation_giver:
-  usr_id: 8000
-  usr_firstname: Értékelés
-  usr_lastname: Leadó Srác
-  usr_screen_name: ertekeles96
-  usr_auth_sch_id: lets-give-this-shit-everywhere-11
+  id: 8000
+  firstname: Értékelés
+  lastname: Leadó Srác
+  screen_name: ertekeles96
+  auth_sch_id: lets-give-this-shit-everywhere-11

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -22,7 +22,7 @@ class MembershipTest < ActionDispatch::IntegrationTest
   end
 
   test 'accepting removes newbie post and sets new member post' do
-    membership = grp_membership(:newbie_membership)
+    membership = membership(:newbie_membership)
 
     assert membership.newbie?
     assert_not membership.new_member?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,6 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     self.use_transactional_fixtures = true
 
-    set_fixture_class grp_membership: Membership
     fixtures :all
 
     # Add more helper methods to be used by all tests here...


### PR DESCRIPTION
Okay, so this is not how it should be, but I had some motivation yesterday..

I had 3 main goals:
- to remove all the `alias_attribute`
- to remove manually set table names
- let AR relations to work without hints