### PR TITLE
Fix timestamps on users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,10 +30,11 @@
 #  last_login              :datetime
 #  auth_sch_id             :string
 #  bme_id                  :string
-#  usr_created_at          :datetime
+#  created_at              :datetime
 #  metascore               :integer
 #  place_of_birth          :string
 #  birth_name              :string
+#  updated_at              :datetime
 #
 
 class User < ApplicationRecord

--- a/db/migrate/20200204185955_fix_timestamps_for_users_table.rb
+++ b/db/migrate/20200204185955_fix_timestamps_for_users_table.rb
@@ -1,0 +1,6 @@
+class FixTimestampsForUsersTable < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :usr_created_at, :created_at
+    add_column :users, :updated_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -622,10 +622,11 @@ CREATE TABLE public.users (
     last_login timestamp without time zone,
     auth_sch_id character varying,
     bme_id character varying,
-    usr_created_at timestamp without time zone,
+    created_at timestamp without time zone,
     metascore integer,
     place_of_birth character varying,
-    birth_name character varying
+    birth_name character varying,
+    updated_at timestamp without time zone
 );
 
 
@@ -1293,6 +1294,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181220204207'),
 ('20190106175754'),
 ('20191025190035'),
-('20200127202810');
+('20200127202810'),
+('20200204185955');
 
 


### PR DESCRIPTION
Using conventional naming will enable automatic management of the timestamps.