### PR TITLE
Update resort leader permissions

### DIFF
--- a/app/controllers/entry_requests_controller.rb
+++ b/app/controllers/entry_requests_controller.rb
@@ -1,5 +1,5 @@
 class EntryRequestsController < ApplicationController
-  before_action :require_leader
+  before_action :require_resort_or_group_leader
 
   def update
     user = User.find params[:user_id]

--- a/app/controllers/point_details_controller.rb
+++ b/app/controllers/point_details_controller.rb
@@ -1,5 +1,5 @@
 class PointDetailsController < ApplicationController
-  before_action :require_leader
+  before_action :require_resort_or_group_leader
   before_action :set_entities
   before_action :changeable_evaluation
 


### PR DESCRIPTION
Closes #174 

Resort leaders can now edit entry requests and point requests in groups that belong under the resort.