### PR TITLE
Determine rails env for building assets in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN bundle install --deployment --without test development --retry 3
 COPY . .
 
 # Build assets
-RUN bundle exec rake assets:precompile
+RUN RAILS_ENV=production bundle exec rake assets:precompile


### PR DESCRIPTION
Without explicit setting it was run in development env and it tried to load the annotate gem from the task, but it is not installed in production.