### PR TITLE
Fix rspec setup

### DIFF
--- a/test/factories/groups.rb
+++ b/test/factories/groups.rb
@@ -1,12 +1,8 @@
 FactoryBot.define do
-  factory :group do
+  factory :basic_group, class: 'Group' do
     name { 'Babhámozó' }
     type { :group }
     sequence(:id, 400)
-
-    after(:create) do |group|
-      group.memberships << create(:membership, :leader, group: group)
-    end
 
     trait :with_additional_info do
       description { 'vietnámiak' }
@@ -16,22 +12,28 @@ FactoryBot.define do
     end
   end
 
-  factory :group_svie, parent: :group do
+  factory :group, parent: :basic_group do
+    after(:create) do |group|
+      group.memberships << create(:membership, :leader, group: group)
+    end
+  end
+
+  factory :group_svie, parent: :basic_group do
     id { Group::SVIE_ID }
     name { 'SVIE' }
   end
 
-  factory :group_rvt, parent: :group do
+  factory :group_rvt, parent: :basic_group do
     id { Group::RVT_ID }
     name { 'RVT' }
   end
 
-  factory :group_kir_dev, parent: :group do
+  factory :group_kir_dev, parent: :basic_group do
     id { Group::KIRDEV_ID }
     name { 'Kir-Dev' }
   end
 
-  factory :group_kb, parent: :group do
+  factory :group_kb, parent: :basic_group do
     id { Group::KB_ID }
     name { 'KB' }
   end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     sequence(:email) { |n| "sanyi_#{n}@example.org" }
     sequence(:cell_phone) { |n| "66677788#{n}" }
     sequence(:neptun) do |n|
-      random_character = (n + 48).chr(Encoding::UTF_8)
+      random_character = (n % 26 + 65).chr(Encoding::UTF_8)
       "AAAAA#{random_character}"
     end
     auth_sch_id { SecureRandom.uuid }


### PR DESCRIPTION
There were two bugs in the setup that caused flaky specs.

- only letters and numbers are allowed in NEPTUN code and in the ASCII table there are some special characters between 58 and 64. Also reaching the end of letters could be problematic, so I added a modulo too
- the second bug was a bit more sophisticated, all the generated groups have leader membership that creates a user and we create some of them for the whole suite. When the NEPTUN sequence started again it had conflict with the ones that are created for the suite.