### PR TITLE
Add status column for membership

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -29,6 +29,8 @@ class Membership < ApplicationRecord
   has_many :posts
   has_many :post_types, through: :posts
 
+  before_create :set_defaults
+
   def leader?
     has_post?(PostType::LEADER_POST_ID)
   end
@@ -48,6 +50,12 @@ class Membership < ApplicationRecord
   def has_post?(post_id)
     posts.any? { |post| post.post_type.id == post_id }
   end
+
+  enum status: {
+    active:   'ACTIVE',
+    archived: 'ARCHIVED',
+    inactive: 'INACTIVE'
+  }, _prefix: :status
 
   def archived?
     !archived.nil?
@@ -71,6 +79,7 @@ class Membership < ApplicationRecord
 
   def inactivate!
     self.end_date = Time.now
+    self.status   = :inactive
 
     user.update(delegated: false) if user.delegated && user.primary_membership == self
     save
@@ -78,11 +87,13 @@ class Membership < ApplicationRecord
 
   def reactivate!
     self.end_date = nil
+    self.status   = :active
     save
   end
 
   def archive!
     self.archived = inactive? ? end_date : Time.now
+    self.status   = :archived
 
     user.update(delegated: false) if user.delegated && user.primary_membership == self
     save
@@ -91,6 +102,7 @@ class Membership < ApplicationRecord
   def unarchive!
     destroy_default_post
     self.archived = nil
+    self.status   = :active
     save
   end
 
@@ -108,5 +120,9 @@ class Membership < ApplicationRecord
   def destroy_default_post
     newbie_post = posts.find { |post| post.post_type.id == PostType::DEFAULT_POST_ID }
     newbie_post&.destroy
+  end
+
+  def set_defaults
+    self.status ||= :active
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,6 +6,7 @@
 #  archived   :date
 #  end_date   :date
 #  start_date :date
+#  status     :string
 #  group_id   :bigint
 #  user_id    :bigint
 #

--- a/db/migrate/20200611204210_add_membership_status.rb
+++ b/db/migrate/20200611204210_add_membership_status.rb
@@ -1,0 +1,5 @@
+class AddMembershipStatus < ActiveRecord::Migration[5.0]
+  def change
+    add_column :memberships, :status, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -269,7 +269,8 @@ CREATE TABLE public.memberships (
     user_id bigint,
     start_date date DEFAULT now(),
     end_date date,
-    archived date
+    archived date,
+    status character varying
 );
 
 
@@ -1464,6 +1465,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190427151354'),
 ('20191025190035'),
 ('20200127202810'),
-('20200204185955');
+('20200204185955'),
+('20200611204210');
 
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -51,4 +51,35 @@ describe Membership do
       expect(membership.user.notifications.count).to eq(1)
     end
   end
+
+  context 'migration to status field' do
+    describe 'create' do
+      it 'sets status to active' do
+        user  = create(:user)
+        group = create(:group)
+
+        membership = Membership.create(user: user, group: group)
+
+        expect(membership).to be_status_active
+      end
+    end
+
+    describe '#inactivate!' do
+      it 'sets status to inactive' do
+        membership = create(:membership)
+
+        membership.inactivate!
+        expect(membership).to be_status_inactive
+      end
+    end
+
+    describe '#archive!' do
+      it 'sets status toarchived' do
+        membership = create(:membership)
+
+        membership.archive!
+        expect(membership).to be_status_archived
+      end
+    end
+  end
 end


### PR DESCRIPTION
I started playing around with `aasm` and I though this could be a good first step on refactoring of membership handling.

I propose the following data migration to be run after deployment
```ruby
# Start with the users that are not inactive nor archived
Membership.where(end_date: nil, archived: nil).update_all(status: :active)
# Currently archivation takes precedence over inactivation
Membership.where.not(archived: nil).update_all(status: :archived)
# Update all left-over to inactive
Membership.where(status: nil).update_all(status: :inactive)
```