### PR TITLE
Fix/strip tags

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -90,7 +90,8 @@ class UserDecorator < Draper::Decorator
   private
 
   def info_box(content, icon)
-    icon = icon_tag(icon)
-    content_tag(:h4, "#{icon} #{sanitize content.to_s}".html_safe, class: 'uk-h4')
+    content_tag(:h4, class: 'uk-h4') do
+      icon_tag(icon) + content
+    end
   end
 end


### PR DESCRIPTION
The sanitize method only removes the dangerous (script) tags and keeps the others.
Strip_tag removes all tags and prevents things like this.

![image](https://user-images.githubusercontent.com/48379676/94167072-5a2d0d80-fe8c-11ea-86a2-56a746d220d3.png)
