### PR TITLE
fix incorrect point_request sum

### DIFF
--- a/app/models/point_detail.rb
+++ b/app/models/point_detail.rb
@@ -31,7 +31,7 @@ class PointDetail < ApplicationRecord
     self.point = valid_point
   end
 
-  after_save do
+  after_commit do
     point_request.recalculate!
   end
 


### PR DESCRIPTION
The sum of the points in a point_request was calculated incorrectly, because in the `after_save`  callback we have the model before the attributes are updated.

As described here: https://apidock.com/rails/ActiveRecord/Callbacks/after_save

The after_commit callback works on the saved instance of the model, so the calculated sum will be correct. 