### PR TITLE
Fix evaluation notification

### DIFF
--- a/app/models/concerns/notifications/evaluation_notifier.rb
+++ b/app/models/concerns/notifications/evaluation_notifier.rb
@@ -57,6 +57,7 @@ module Notifications
 
     def notify_from_status_change
       return unless SystemAttribute.evaluation_season?
+      return unless group&.parent&.leader&.user.present?
 
       key = EvaluationNotificationKey.new("point_request", point_request_status)
       notify(:users, key: key.to_s , notifier: sender(key)) if point_request_status_changed?

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -33,6 +33,20 @@ describe Evaluation do
         User.includes(:notifications).all.map(&:notifications).flatten.count
       }.by(1)
     end
+
+    context 'the group parent does not have a leader' do
+      before(:each) do
+        evaluation.group.parent.leader.delete
+      end
+
+      it 'submitting a point request does not notify the resort leader' do
+        expect {
+          evaluation.update(point_request_status: Evaluation::NOT_YET_ASSESSED)
+        }.to change {
+          User.includes(:notifications).all.map(&:notifications).flatten.count
+        }.by(0)
+      end
+    end
   end
 
   context "when application season" do

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -36,7 +36,7 @@ describe Evaluation do
 
     context 'the group parent does not have a leader' do
       before(:each) do
-        evaluation.group.parent.leader.delete
+        evaluation.group.parent.leader.destroy
       end
 
       it 'submitting a point request does not notify the resort leader' do


### PR DESCRIPTION
Notifications realted to evaluation status changes chrashed when a grop had no parent or the parent had no leader.

If there is no parent or leader it returns. 