### PR TITLE
separate uplodas folder from public

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     env_file:
       - .env
     volumes:
-      - public_folder:/pek-next/public
+      - uploads_folder:/pek-next/public/uploads
     ports:
       - "3443:3000"
     networks:
@@ -54,9 +54,9 @@ networks:
 
 # Add your volumes
 volumes:
-  public_folder:
+  uploads_folder:
     external:
-      name: pek_public
+      name: pek_uploads
   database_folder:
     external:
       name: pek_database


### PR DESCRIPTION
## What's new?
Assets are no longer in the public volume, so the old versions will not overwirite the new ones.
The PR create a new volume for the profile images contained in the uploads folder.
The old volume will we kept, just in case.

## Steps to deploy
Copy out the images from the container:
`docker cp penknext_web_1:/pek-next/public/uploads HOST_FOLDER`

Pull the new dokcer-compose file:
`git pull`

Stop the running containers:
`docker-compose down`

Create the new volume:

`docker volume create --name=pek_uploads`

Build and start the containers:
`docker-compose up --build -d`

Copy in the uploads folder:
`docker cp HOST_FOLDER peknext_web_1:/pek-next/public/`