### PR TITLE
fix delegates export page button

### DIFF
--- a/app/views/admin/delegates/export.html.erb
+++ b/app/views/admin/delegates/export.html.erb
@@ -3,7 +3,7 @@
 <div id="content-main" class="neutral-content">
 <h1 class="no-print">Küldöttek listázása</h1>
 
-<%= button_to 'Exportálás', 'javascript:window.print()', class: 'uk-button uk-button-large uk-button-primary uk-align-right' %>
+<%= button_to 'Exportálás', '', onclick: 'javascript:window.print()', class: 'uk-button uk-button-large uk-button-primary uk-align-right' %>
 
 <table border="1" class="uk-table uk-table-striped uk-table-hover">
   <thead>


### PR DESCRIPTION
Probably in Rails 6 the used weird parameter format is no longer supported.