### PR TITLE
fix button on svie pdf

### DIFF
--- a/app/views/svie/application_pdf.html.erb
+++ b/app/views/svie/application_pdf.html.erb
@@ -9,7 +9,8 @@
   <%= stylesheet_link_tag    'svie_member_request_pdf.css', media: 'all' %>
 </head>
 
-<%= button_to 'Nyomtatás', 'javascript:window.print()', class: 'uk-button uk-button-large uk-button-success uk-align-center no-print' %>
+<%= button_tag 'Nyomtatás', onclick:'javascript:window.print()',
+                            class: 'uk-button uk-button-large uk-button-success uk-align-center no-print' %>
 
 <body>
 <table class="uk-table">


### PR DESCRIPTION
Rollbar caught an error that was cased by this.
The problem was that Rails 6 has a different syntax on buttons with javascript.