### PR TITLE
move pid file to /tmp folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - pek_network
   web:
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bundle exec rails s -p 3000 -b '0.0.0.0' -P /tmp/server.pid
     environment:
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_ENV=production


### PR DESCRIPTION
Move the server's pid file to the /tmp folder to enable restart after crash.