### PR TITLE
remove pid before start up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - pek_network
   web:
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0' -P /tmp/server.pid
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_ENV=production


### PR DESCRIPTION
Putting the pid file in /tmp is not a robust solution, because the containers are kept after failiuers(so the /tmp folder is not emptied).
More on container lifecycles:
https://medium.com/@BeNitinAgarwal/lifecycle-of-docker-container-d2da9f85959

The only certain solution seems to be removing the pid file manually, as advised in the offical documentation.
https://docs.docker.com/samples/rails/