### PR TITLE
enable evaluation helpers to edit posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,7 @@
 class PostsController < ApplicationController
-  before_action :require_leader
-
   def index
     @group = Group.find(params[:group_id])
+    authorize @group, :manage_posts?
     @membership = Membership.find(params[:membership_id])
   end
 
@@ -10,6 +9,7 @@ class PostsController < ApplicationController
     group = Group.find(params[:group_id])
     membership = Membership.find(params[:membership_id])
     post_type_id = params[:post_type_id].to_i
+    authorize Post.new(membership: membership, post_type_id: post_type_id)
 
     new_post = CreatePost.call(group, membership, post_type_id)
     return redirect_to group_path(group) if new_post.leader?
@@ -20,6 +20,7 @@ class PostsController < ApplicationController
   def destroy
     post_id = params[:id]
     group_url = group_path(params[:group_id])
+    authorize Post.find(post_id)
     return redirect_back fallback_location: group_url if DestroyPost.call(post_id)
 
     redirect_back fallback_location: group_url, alert: t(:no_leader_error)

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -22,6 +22,8 @@ class GroupPolicy < ApplicationPolicy
     leader? || (group == Group.sssl && evaluation_helper?)
   end
 
+  alias manage_posts? manage_memberships?
+
   private
 
   alias group record

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,0 +1,33 @@
+class PostPolicy < ApplicationPolicy
+  alias post record
+
+  def create?
+    return false unless group&.has_post_type?(post_type.id)
+    return true if leader?
+    return true if group == Group.sssl && evaluation_helper? &&
+                   (group.own_post_types.include?(post_type) ||
+                    post_type.id == PostType::NEW_MEMBER_ID)
+
+    false
+  end
+
+  alias destroy? create?
+
+  private
+
+  def group
+    post.membership.group
+  end
+
+  def post_type
+    post.post_type
+  end
+
+  def leader?
+    user.leader_of?(group)
+ end
+
+  def evaluation_helper?
+    user.evaluation_helper_of?(group)
+  end
+end

--- a/app/services/destroy_post.rb
+++ b/app/services/destroy_post.rb
@@ -1,6 +1,7 @@
 class DestroyPost
   def self.call(post_id)
     post = Post.find(post_id)
+    raise InvalidPostType unless post.membership.group.has_post_type?(post.post_type_id)
     return false if post.post_type_id == PostType::LEADER_POST_ID
 
     post.destroy

--- a/app/views/groups/_group_member_grid_item.html.erb
+++ b/app/views/groups/_group_member_grid_item.html.erb
@@ -5,7 +5,7 @@
       <div class="uk-padding-remove uk-float-left">
         <%= member.user_link %>
       </div>
-      <% if @viewmodel.leader? %>
+      <% if @can_manage_memberships %>
         <div class="uk-float-right">
           <%= member.svie_status_icon %>
           <div class="uk-padding-remove uk-text-right uk-float-right uk-margin-small-left">

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -1,0 +1,41 @@
+describe PostPolicy, type: :policy do
+  subject { described_class }
+
+  permissions :create?, :destroy? do
+    let(:membership) { create(:membership) }
+    let(:post_type) { create(:post_type, group: membership.group) }
+    let(:post) { create(:post, :newbie, membership: membership, post_type: post_type) }
+
+    context "when the current user is the group leader" do
+      let(:user) { membership.group.leader.user }
+
+      it "is permitted" do
+        expect(subject).to permit(user, post)
+      end
+    end
+
+    context "when the user is not a member" do
+      let(:user) { create(:user) }
+      it "is forbidden" do
+        expect(subject).not_to permit(user, post)
+      end
+    end
+
+    context "when the group is the SSSL" do
+      let(:membership) { create(:membership, group: Group::sssl) }
+
+      context "and the current user is the evaluation helper" do
+        before(:each) do
+          membership = Membership.create!(user: user, group: Group::sssl)
+          Post.create!(membership: membership, post_type_id: PostType::EVALUATION_HELPER_ID)
+        end
+
+        let(:user) { create(:user) }
+
+        it "is permitted" do
+          expect(subject).to permit(user, post)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What's new
Evaluation helpers in the SSSL are now able to manage posts that have no special privileges. 
The FINANCIAL_OFFICER_POST, LEADER_POST, EVALUATION_HELPER is still managed only by the leader.