### PR TITLE
fix new group button

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -36,7 +36,7 @@
                 <% unless SystemAttribute.offseason? %>
                   <li><%= link_to 'Értékelések', judgements_path %></li>
                 <% end %>
-                <% if GroupPolicy.new(current_user, current_group).new? %>
+                <% if GroupPolicy.new(current_user, nil).new? %>
                   <li><%= link_to 'Kör létrehozása', new_group_path %></li>
                 <% end %>
               </ul>


### PR DESCRIPTION
The authorization logic does not need the group parameter, it can perform the authoriyation only based on the user so this can be removed.
Also current group could break if it is called on a non-group page.