### PR TITLE
make search open with ctrl + /

### DIFF
--- a/app/assets/javascripts/application/search.js
+++ b/app/assets/javascripts/application/search.js
@@ -55,8 +55,25 @@ var search = (function(Helpers, Rx, $) {
     }
   }
 
-  function focusSearchField(event) {
-    if (event.key == '/') {
+  let pressedKeys = {
+      "Control":false,
+      "/":false
+  }
+
+  function listenForKeyDown(event){
+      pressedKeys[event.key] = true;
+      focusSearchField()
+  }
+
+  function listenForKeyUp(event){
+      pressedKeys[event.key] = false;
+  }
+
+  document.addEventListener("keydown", listenForKeyDown);
+  document.addEventListener("keyup", listenForKeyUp);
+
+  function focusSearchField() {
+    if (pressedKeys["Control"] && pressedKeys["/"]) {
       const element = document.getElementById('search-field');
       element.focus();
     }


### PR DESCRIPTION
The search bar got selected when users hit the `/` key anywhere in the application.
This could cause problems when someone wrote a comment with `/`.
So I changed the shortcut for search to `ctrl + /` 