### PR TITLE
make new lines visible in EvaluationComments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -142,3 +142,7 @@ html, body {
 .tm-footer p, .tm-footer ul {
 	margin: 0;
 }
+
+.pre-wrap{
+    white-space: pre-wrap;
+}

--- a/app/views/point_detail_comments/_show.html.erb
+++ b/app/views/point_detail_comments/_show.html.erb
@@ -11,6 +11,6 @@
       <%= comment.created_at %>
     </div>
   </header>
-  <div class="uk-comment-body"><%= comment.comment %></div>
+  <div class="uk-comment-body pre-wrap"><%= comment.comment %></div>
   <%= comment.closing_status %>
 </article>


### PR DESCRIPTION
New lines were not rendered is the text of PointDetails Comment.
This css attribute fixes the problem.

More info:
https://developer.mozilla.org/en-US/docs/Web/CSS/white-space