### PR TITLE
Fix notification methods

### DIFF
--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -20,7 +20,7 @@ class NotificationDecorator < Draper::Decorator
   def mark_as_read_link(options = {})
     return unless unopened?
 
-    options[:method] = :post
+    options[:method] = :put
     options[:remote] = true
     path = open_notification_path_for(self, base_params.merge(reload: false))
     link = link_to('Olvasottnak jelölés', path, options)
@@ -33,7 +33,7 @@ class NotificationDecorator < Draper::Decorator
 
     if unopened?
       path = open_notification_path_for(self, base_params.merge(move: true))
-      options[:method] = :post
+      options[:method] = :put
     else
       path = move_notification_path_for(self, base_params)
     end


### PR DESCRIPTION
When a user opens or marks a notification read they got a Routing Error.
![Screenshot from 2021-05-12 10-58-06](https://user-images.githubusercontent.com/48379676/118022294-11d63900-b311-11eb-9cd9-db9795cfeb0a.png)

Probaly the `acivity_notification` gem changed the open actions HTTP method in a recent version.
The current method for the action is PUT (as shown in the image), but the view used POST.

![Screenshot from 2021-05-11 13-44-44](https://user-images.githubusercontent.com/48379676/117882367-1e9a5480-b25f-11eb-9f02-eb26c8408819.png)

Updating the method fixed the issue.