### PR TITLE
improve hungarian collation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,6 @@ gem 'unsplash'
 gem 'activity_notification', '~> 2.2', '>= 2.2.1'
 # use Pundit for authorization
 gem 'pundit', '~> 2.1'
-# use twitter_cldr for localization improvements (sorting strings according to hungarian)
-gem 'twitter_cldr', '~> 6.4'
 gem "bootsnap", ">= 1.1.0", require: false
 gem 'listen'
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,6 @@ GEM
     brakeman (4.7.0)
     builder (3.2.4)
     byebug (11.0.1)
-    camertron-eprun (1.1.1)
-    cldr-plurals-runtime-rb (1.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.2)
@@ -312,10 +310,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
-    twitter_cldr (6.4.0)
-      camertron-eprun
-      cldr-plurals-runtime-rb (~> 1.1)
-      tzinfo
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -370,7 +364,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   timecop
-  twitter_cldr (~> 6.4)
   uglifier (~> 3.2.0)
   unsplash
   wkhtmltopdf-binary (~> 0.12.3.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,6 @@ module ApplicationHelper
   end
 
   def hu_compare(a, b)
-    TwitterCldr::Collation::Collator.new(:hu).compare(a, b)
+    HungarianComparator.compare(a, b)
   end
 end

--- a/app/services/hungarian_comparator.rb
+++ b/app/services/hungarian_comparator.rb
@@ -1,0 +1,25 @@
+class HungarianComparator
+  ALPHABET = Rails.configuration.x.hun_alphabet
+  CHARACTER_VALUES = ALPHABET.map.with_index { |char, i| [char, i] }.to_h
+
+  def self.compare(a_string, b_string)
+    a_characters = hungarian_characters(a_string)
+    b_characters = hungarian_characters(b_string)
+    index = 0
+    while index < a_characters.length && index < b_characters.length
+      comparison_result = value(a_characters[index]) <=> value(b_characters[index])
+      return comparison_result unless comparison_result.zero?
+
+      index += 1
+    end
+    a_characters.length <=> b_characters.length
+  end
+
+  def self.value(character)
+    CHARACTER_VALUES[character]
+  end
+
+  def self.hungarian_characters(string)
+    string.downcase.split('').select { |character| CHARACTER_VALUES[character] }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,6 +109,11 @@ module PekNext
     config.x.neptun_regex = /^[A-Za-z0-9]{6,7}$/
     config.x.uuid_regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
 
+    config.x.hun_alphabet = ['a', 'á', 'b', 'c', 'd', 'e', 'é', 'f', 'g',
+                             'h', 'i', 'í', 'j', 'k', 'l', 'm', 'n', 'o',
+                             'ó', 'ö', 'ő', 'p', 'q', 'r', 's', 't', 'u',
+                             'ú', 'ü', 'ű', 'v', 'w', 'x', 'y', 'z']
+
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
 
   end

--- a/spec/services/hungarian_comparator_spec.rb
+++ b/spec/services/hungarian_comparator_spec.rb
@@ -1,0 +1,24 @@
+describe HungarianComparator do
+  subject { proc { |a, b| HungarianComparator.compare(a, b) } }
+
+  it 'should ignore punctuations' do
+    input = ['c++', '.-B', 'A']
+    expected = ['A', '.-B', 'c++']
+    result = input.sort(&subject)
+    expect(result).to eql(expected)
+  end
+
+  it 'should handle strings which start with identical substring' do
+    input = ['alma fa', 'alma faház', 'alma']
+    expected = ['alma', 'alma fa', 'alma faház']
+    result = input.sort(&subject)
+    expect(result).to eql(expected)
+  end
+
+  it 'should handle hungarian letters correctly' do
+    input = ['Árok Part', 'Alma Fa', 'Olasz Paradicsom', 'Úr Iember','Örök Zöld', 'Uszo Da']
+    expected = ['Alma Fa', 'Árok Part', 'Olasz Paradicsom', 'Örök Zöld', 'Uszo Da', 'Úr Iember']
+    result = input.sort(&subject)
+    expect(result).to eql(expected)
+  end
+end


### PR DESCRIPTION
## What is new?
- Improved collation for hungarian characters

## Details
- I did not find any external library that can do an accurate comparison between hungarian words
- The previously used comparator produced some innaccurate results (Like Á < A)
  - This implementation solves this issue
- The comparison is still not completly proper
  - Not all collation rules are implemented (Like letters that that consist of 2 or more character are not handled approprietly)   