### PR TITLE
Enable evaluation helpers to comment

### DIFF
--- a/app/policies/evaluation_policy.rb
+++ b/app/policies/evaluation_policy.rb
@@ -3,7 +3,7 @@ class EvaluationPolicy < ApplicationPolicy
     return false if off_season?
 
     return true if leader_of_the_group? || evaluation_helper_of_the_group?
-    return true if leader_of_the_resort? || leader_in_the_resort?
+    return true if leader_of_the_resort? || leader_in_the_resort? || evaluation_helper_in_the_resort?
     return true if pek_admin? || rvt_member?
 
     false
@@ -23,6 +23,7 @@ class EvaluationPolicy < ApplicationPolicy
 
   def update_comments?
     return true if leader_of_the_group? || evaluation_helper_of_the_group?
+    return true if leader_in_the_resort? || evaluation_helper_in_the_resort?
     return true if rvt_member?
 
     false
@@ -114,6 +115,15 @@ class EvaluationPolicy < ApplicationPolicy
     return false unless group_is_a_resort_member?
 
     cache { evaluation.group.parent&.children&.any? { |group| user.leader_of?(group) } }
+  end
+
+  def evaluation_helper_in_the_resort?
+    return false unless group_is_a_resort_member?
+
+    resort_groups = evaluation.group.parent&.children
+    resort_memberships = Membership.where(user: user, group: resort_groups)
+    evaluation_helper_posts = Post.where(membership: resort_memberships, post_type_id: PostType::EVALUATION_HELPER_ID)
+    !evaluation_helper_posts.empty?
   end
 
   def group_is_a_resort_member?

--- a/spec/policies/evaluation_policy_spec.rb
+++ b/spec/policies/evaluation_policy_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe EvaluationPolicy, type: :policy do
   let(:submit_actions)          { %i[submit_point_request submit_entry_request] }
   let(:cancel_actions)          { %i[cancel_point_request cancel_entry_request] }
   let(:update_request_actions)  { %i[update_point_request update_entry_request] }
+  let(:update_comment_actions)  { %i[update_comments] + evaluation_view_actions }
   let(:all_action)              { entry_request_actions + point_request_actions + evaluation_actions }
 
   context 'when application season' do
@@ -18,6 +19,7 @@ RSpec.describe EvaluationPolicy, type: :policy do
       let(:user) { evaluation.group.leader.user }
 
       it { is_expected.to permit_actions(all_action - cancel_actions) }
+      it { is_expected.to permit_actions(update_comment_actions) }
       it { is_expected.to forbid_actions(cancel_actions) }
 
       context "and the request is submitted" do

--- a/spec/policies/evaluation_policy_spec.rb
+++ b/spec/policies/evaluation_policy_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe EvaluationPolicy, type: :policy do
       it { is_expected.to permit_actions(evaluation_view_actions) }
       it { is_expected.to forbid_actions(all_action - evaluation_view_actions) }
     end
+
+    context 'and the user is an evaluation helper in the group resort' do
+      let(:user) do
+        evaluation.group.parent.children.reject do |group|
+          group == evaluation.group
+        end.first.leader.user
+      end
+
+      it { is_expected.to permit_actions(evaluation_view_actions) }
+      it { is_expected.to forbid_actions(all_action - evaluation_view_actions) }
+    end
   end
 
   context 'when evaluation season' do

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -4,13 +4,13 @@ describe PostPolicy, type: :policy do
   permissions :create?, :destroy? do
     let(:membership) { create(:membership) }
     let(:post_type) { create(:post_type, group: membership.group) }
-    let(:post) { create(:post, :newbie, membership: membership, post_type: post_type) }
+    let(:post) { create(:post, membership: membership, post_type: post_type) }
 
     context "when the current user is the group leader" do
       let(:user) { membership.group.leader.user }
 
       it "is permitted" do
-        expect(subject).to permit(user, post)
+        expect(subject).to permit(user, post.reload)
       end
     end
 

--- a/test/factories/groups.rb
+++ b/test/factories/groups.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
     after(:create) do |group|
       group.memberships << create(:membership, :leader, group: group)
     end
+
+    after(:create) do |group|
+      user = create(:user)
+      membership = Membership.create!(user: user, group: group)
+      CreatePost.call(group, membership, PostType::EVALUATION_HELPER_ID)
+    end
   end
 
   factory :group_with_parent, parent: :group do
@@ -28,14 +34,6 @@ FactoryBot.define do
     after(:create) do |group|
       sibling_group = create(:group)
       sibling_group.update(parent: group.parent)
-    end
-
-    after(:create) do |group|
-      user = create(:user)
-      Membership::CreateService.call(group, user)
-      membership = user.membership_for(group)
-      CreatePost.call(group, membership, PostType::EVALUATION_HELPER_ID)
-      ActivityNotification::Notification.last.delete
     end
   end
 


### PR DESCRIPTION
## What is new?
- Closes #325 
- The group leaders and evaluation helpers can view and comment on other groups evaluation in their resort.
- Group factory is refactord to make a mebership with evaluation helper post to each group. This makes testing policies more straight forward, and less tedious to set up.
- Add test for comment action