### PR TITLE
enable membership and post administration to all evaluation_helper

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -19,7 +19,7 @@ class GroupPolicy < ApplicationPolicy
   alias new? create?
 
   def manage_memberships?
-    leader? || (group == Group.sssl && evaluation_helper?)
+    leader? || evaluation_helper?
   end
 
   alias manage_posts? manage_memberships?

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -4,7 +4,7 @@ class PostPolicy < ApplicationPolicy
   def create?
     return false unless group&.has_post_type?(post_type.id)
     return true if leader?
-    return true if group == Group.sssl && evaluation_helper? &&
+    return true if evaluation_helper? &&
                    (group.own_post_types.include?(post_type) ||
                     post_type.id == PostType::NEW_MEMBER_ID)
 

--- a/app/viewmodels/membership_view_model.rb
+++ b/app/viewmodels/membership_view_model.rb
@@ -6,7 +6,7 @@ class MembershipViewModel
     @group = Group.includes([:members, { memberships: [:post_types] }]).find(group_id)
     @membership = user.membership_for(group)
     @leader = membership&.leader?
-    @sssl_evaluation_helper = (membership&.group == Group.sssl && membership&.evaluation_helper?)
+    @sssl_evaluation_helper = membership&.evaluation_helper?
     @resort_leader = @user&.roles&.resort_leader?(@group)
   end
 


### PR DESCRIPTION
## What is new?
- All evaluation helper can manage posts and memberships, not just in SSSL.