### PR TITLE
Improve evaluation judgement

### DIFF
--- a/app/policies/evaluation_policy.rb
+++ b/app/policies/evaluation_policy.rb
@@ -29,12 +29,6 @@ class EvaluationPolicy < ApplicationPolicy
     false
   end
 
-  def edit_justification?
-    return false unless submittable_request?(entry_request_status)
-
-    leader_of_the_group? || evaluation_helper_of_the_group?
-  end
-
   def update_point_request?
     update_request?(point_request_status)
   end
@@ -50,6 +44,7 @@ class EvaluationPolicy < ApplicationPolicy
   def update_entry_request?
     update_request?(entry_request_status)
   end
+  alias edit_justification? update_entry_request?
 
   def submit_entry_request?
     submit_request?(entry_request_status)

--- a/spec/policies/evaluation_policy_spec.rb
+++ b/spec/policies/evaluation_policy_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe EvaluationPolicy, type: :policy do
     context "when the user is the resort leader" do
       let(:user) { evaluation.group.parent.leader.user }
 
-      it { is_expected.to permit_actions(update_request_actions + evaluation_view_actions) }
-      it { is_expected.to forbid_actions(all_action - (update_request_actions + evaluation_view_actions)) }
+      it { is_expected.to permit_actions(update_request_actions + evaluation_view_actions + [:edit_justification]) }
+      it { is_expected.to forbid_actions(all_action - (update_request_actions + evaluation_view_actions) - [:edit_justification]) }
 
       context "and the point and entry request is accepted" do
         before do
@@ -151,8 +151,8 @@ RSpec.describe EvaluationPolicy, type: :policy do
     context "when the user is the leader of RVT" do
       let(:user) { Group.rvt.leader.user }
 
-      it { is_expected.to permit_actions(update_request_actions + evaluation_view_actions) }
-      it { is_expected.to forbid_actions(all_action - (update_request_actions + evaluation_view_actions)) }
+      it { is_expected.to permit_actions(update_request_actions + evaluation_view_actions + [:edit_justification]) }
+      it { is_expected.to forbid_actions(all_action - (update_request_actions + evaluation_view_actions) - [:edit_justification]) }
 
       context "and the point and entry request is accepted" do
         before do


### PR DESCRIPTION
## What's new?
- Enable anyone who can update entry request to edit the corresponding justifications.  (group leader+ evaluation helper + Resort and RVT leader ) 
