### PR TITLE
make webpage clickable on profile

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -84,7 +84,8 @@ class UserDecorator < Draper::Decorator
     return if user.webpage.blank?
     return unless Privacy.for(user, 'WEBPAGE').visible
 
-    info_box(user.webpage, 'uk-icon-link')
+    link = link_to(user.webpage, user.webpage)
+    info_box(link, 'uk-icon-link')
   end
 
   private


### PR DESCRIPTION
This PR closes #357. 

Website links provided in the user profile are now navigatable.
The links must be valid URLs or the browsers may not handle them properly. 
Scheme and path both must be provided. I.E.:
[https://github.com/kir-dev](https://github.com/kir-dev
)

