### PR TITLE
Improve post mgmt

### DIFF
--- a/app/assets/javascripts/application/posts.js
+++ b/app/assets/javascripts/application/posts.js
@@ -1,0 +1,57 @@
+function removePost(group_id, membership_id, post_type_id, post_id) {
+    const button = document.getElementById(`remove-${membership_id}-${post_type_id}`)
+    button.disabled = true
+    fetch(`/groups/${group_id}/memberships/${membership_id}/posts/${post_id}.json`,
+        {
+            headers: {
+                'X-CSRF-TOKEN': getCsrfToken(),
+                // 'Content-Type': 'application/json'
+            },
+            method: 'DELETE',
+            credentials: 'same-origin',
+        })
+        .then(response => {
+            if (response.status === 200) {
+                button.onclick = () => addPost(group_id, membership_id, post_type_id)
+                button.id = `add-${membership_id}-${post_type_id}`
+
+                button.classList.remove("uk-button-danger")
+                button.classList.add("uk-button-success")
+
+                const buttonTexts = button.innerText.split('(')
+                buttonTexts[1] = "(Hozzáad)"
+                button.innerText = buttonTexts.join('')
+                button.disabled = false
+            }
+        })
+}
+
+function addPost(group_id, membership_id, post_type_id) {
+    const button = document.getElementById(`add-${membership_id}-${post_type_id}`)
+    button.disabled = true
+    fetch(`/groups/${group_id}/memberships/${membership_id}/posts.json`, {
+        headers: {
+            'X-CSRF-TOKEN': getCsrfToken(),
+            'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        credentials: 'same-origin',
+        body: JSON.stringify({post_type_id: post_type_id})
+    }).then(response => {
+        if (response.status === 200) {
+            response.json().then(data => {
+                button.onclick = () => removePost(group_id, membership_id, post_type_id, data.post_id)
+                button.id = `remove-${membership_id}-${post_type_id}`
+
+                button.classList.remove("uk-button-success")
+                button.classList.add("uk-button-danger")
+
+                const buttonTexts = button.innerText.split('(')
+                buttonTexts[1] = "(Elvesz)"
+                button.innerText = buttonTexts.join('')
+
+                button.disabled = false
+            });
+        }
+    })
+}

--- a/app/assets/javascripts/application/posts.js
+++ b/app/assets/javascripts/application/posts.js
@@ -1,11 +1,10 @@
 function removePost(group_id, membership_id, post_type_id, post_id) {
-    const button = document.getElementById(`remove-${membership_id}-${post_type_id}`)
+    const button = document.getElementById(`post-action-button-${membership_id}-${post_type_id}`)
     button.disabled = true
     fetch(`/groups/${group_id}/memberships/${membership_id}/posts/${post_id}.json`,
         {
             headers: {
                 'X-CSRF-TOKEN': getCsrfToken(),
-                // 'Content-Type': 'application/json'
             },
             method: 'DELETE',
             credentials: 'same-origin',
@@ -13,7 +12,6 @@ function removePost(group_id, membership_id, post_type_id, post_id) {
         .then(response => {
             if (response.status === 200) {
                 button.onclick = () => addPost(group_id, membership_id, post_type_id)
-                button.id = `add-${membership_id}-${post_type_id}`
 
                 button.classList.remove("uk-button-danger")
                 button.classList.add("uk-button-success")
@@ -27,7 +25,7 @@ function removePost(group_id, membership_id, post_type_id, post_id) {
 }
 
 function addPost(group_id, membership_id, post_type_id) {
-    const button = document.getElementById(`add-${membership_id}-${post_type_id}`)
+    const button = document.getElementById(`post-action-button-${membership_id}-${post_type_id}`)
     button.disabled = true
     fetch(`/groups/${group_id}/memberships/${membership_id}/posts.json`, {
         headers: {
@@ -41,7 +39,6 @@ function addPost(group_id, membership_id, post_type_id) {
         if (response.status === 200) {
             response.json().then(data => {
                 button.onclick = () => removePost(group_id, membership_id, post_type_id, data.post_id)
-                button.id = `remove-${membership_id}-${post_type_id}`
 
                 button.classList.remove("uk-button-success")
                 button.classList.add("uk-button-danger")

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -2,7 +2,7 @@
 .wrapper {
     position: relative;
     overflow: auto;
-    border: 1px solid black;
+    border: 1px solid lightgray;
     white-space: nowrap;
 }
 
@@ -20,7 +20,11 @@
     white-space: normal;
 }
 
-tr:hover {
+td, thead {
+   background-color: white;
+}
+
+tr:hover > td {
     background-color: #99baca;
 }
 

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -1,0 +1,29 @@
+
+.wrapper {
+    position: relative;
+    overflow: auto;
+    border: 1px solid black;
+    white-space: nowrap;
+}
+
+.sticky-col {
+    position: -webkit-sticky;
+    position: sticky;
+    background-color: white;
+}
+
+.first-col {
+    width: 120px;
+    min-width: 120px;
+    max-width: 120px;
+    left: 0px;
+    white-space: normal;
+}
+
+tr:hover {
+    background-color: #99baca;
+}
+
+tr:hover > .first-col {
+    background-color: #99baca;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,18 @@ class PostsController < ApplicationController
     @membership = Membership.find(params[:membership_id])
   end
 
+  def group_posts
+    @group = Group.includes(:post_types, :memberships).find(params[:group_id])
+    authorize @group, :manage_posts?
+
+    @post_type_ids = @group.post_types.map(&:id)
+    @post_type_ids.delete(PostType::LEADER_POST_ID)
+    @group_post_types = {}
+    @group.post_types.each { |post_type| @group_post_types[post_type.id] = post_type }
+    @memberships = @group.memberships.active.includes(:posts, :user)
+    @memberships = @memberships.sort { |a, b| hu_compare(a.user.full_name, b.user.full_name) }
+  end
+
   def create
     group = Group.find(params[:group_id])
     membership = Membership.find(params[:membership_id])
@@ -12,17 +24,32 @@ class PostsController < ApplicationController
     authorize Post.new(membership: membership, post_type_id: post_type_id)
 
     new_post = CreatePost.call(group, membership, post_type_id)
-    return redirect_to group_path(group) if new_post.leader?
+    respond_to do |format|
+      format.html do
+        return redirect_to group_path(group) if new_post.leader?
 
-    redirect_back fallback_location: group_path(group)
+        redirect_back fallback_location: group_path(group)
+      end
+      format.json { render json: { post_id: new_post.id } }
+    end
   end
 
   def destroy
     post_id = params[:id]
     group_url = group_path(params[:group_id])
     authorize Post.find(post_id)
-    return redirect_back fallback_location: group_url if DestroyPost.call(post_id)
 
-    redirect_back fallback_location: group_url, alert: t(:no_leader_error)
+    destroyed = DestroyPost.call(post_id)
+    respond_to do |format|
+      format.html do
+        return redirect_back fallback_location: group_url if destroyed
+
+        redirect_back fallback_location: group_url, alert: t(:no_leader_error)
+      end
+      format.json {
+        return render plain: 'ok', status: :ok
+      }
+    end
+
   end
 end

--- a/app/decorators/membership_view_model_decorator.rb
+++ b/app/decorators/membership_view_model_decorator.rb
@@ -57,6 +57,12 @@ end
                    'uk-button-success')
   end
 
+  def all_posts_button
+    return unless policy(current_group).manage_posts?
+
+    styled_link_to('Posztok kezelése', group_posts_path(current_group), 'uk-button-success')
+  end
+
   def all_members_count
     membership_view_model.group.memberships.count
   end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -18,6 +18,7 @@
           <%= @viewmodel.join_group_button %>
           <%= @viewmodel.withdraw_membership_button %>
           <%= @viewmodel.evaluation_button %>
+          <%= @viewmodel.all_posts_button %>
         </div>
       </div>
 

--- a/app/views/posts/group_posts.html.erb
+++ b/app/views/posts/group_posts.html.erb
@@ -3,7 +3,6 @@
 <%= button_to "Vissza", group_path(@group.id), method: :get,
               class: "uk-button uk-button-primary uk-button-large uk-margin-bottom" %>
 
-
 <div class="view">
   <div class="wrapper">
     <table id="posts-table" class="table">
@@ -17,7 +16,6 @@
       </thead>
       <tbody>
       <% @memberships.each do |membership| %>
-
         <tr>
           <td class="sticky-col first-col">
             <%= link_to membership.user.full_name, profile_path(membership.user.screen_name), target: :blank, rel: "noreferrer" %>
@@ -29,10 +27,10 @@
             <td class="uk-vertical-align">
               <% if post.present? %>
                 <%= button_tag "#{post_type.name} (Elvesz)", class: "uk-button uk-button-danger uk-width-1-1 uk-align-center",
-                               id: "remove-#{membership.id}-#{post_type_id}", onclick: "removePost(#{@group.id}, #{membership.id},#{post_type_id}, #{post.id})" %>
+                               id: "post-action-button-#{membership.id}-#{post_type_id}", onclick: "removePost(#{@group.id}, #{membership.id},#{post_type_id}, #{post.id})" %>
               <% else %>
                 <%= button_tag "#{post_type.name} (Hozzáad)", class: "uk-button uk-button-success uk-width-1-1 uk-align-center",
-                               id: "add-#{membership.id}-#{post_type_id}", onclick: "addPost(#{@group.id}, #{membership.id},#{post_type_id})" %>
+                               id: "post-action-button-#{membership.id}-#{post_type_id}", onclick: "addPost(#{@group.id}, #{membership.id},#{post_type_id})" %>
               <% end %>
           <% end %>
         </tr>

--- a/app/views/posts/group_posts.html.erb
+++ b/app/views/posts/group_posts.html.erb
@@ -1,0 +1,46 @@
+<%= stylesheet_link_tag params[:controller] %>
+
+<%= button_to "Vissza", group_path(@group.id), method: :get,
+              class: "uk-button uk-button-primary uk-button-large uk-margin-bottom" %>
+
+
+<div class="view">
+  <div class="wrapper">
+    <table id="posts-table" class="table">
+      <thead>
+      <tr>
+        <th class="sticky-col first-col"></th>
+        <% @post_type_ids.each do |id| %>
+          <th><%= @group_post_types[id].name %></th>
+        <% end %>
+      </tr>
+      </thead>
+      <tbody>
+      <% @memberships.each do |membership| %>
+
+        <tr>
+          <td class="sticky-col first-col">
+            <%= link_to membership.user.full_name, profile_path(membership.user.screen_name), target: :blank, rel: "noreferrer" %>
+          </td>
+          <% @post_type_ids.each do |post_type_id| %>
+            <% post = membership.posts.to_a.find { |post| post.post_type_id == post_type_id } %>
+            <% post_type = @group_post_types[post_type_id] %>
+
+            <td class="uk-vertical-align">
+              <% if post.present? %>
+                <%= button_tag "#{post_type.name} (Elvesz)", class: "uk-button uk-button-danger uk-width-1-1 uk-align-center",
+                               id: "remove-#{membership.id}-#{post_type_id}", onclick: "removePost(#{@group.id}, #{membership.id},#{post_type_id}, #{post.id})" %>
+              <% else %>
+                <%= button_tag "#{post_type.name} (Hozzáad)", class: "uk-button uk-button-success uk-width-1-1 uk-align-center",
+                               id: "add-#{membership.id}-#{post_type_id}", onclick: "addPost(#{@group.id}, #{membership.id},#{post_type_id})" %>
+              <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= button_to "Vissza", group_path(@group.id), method: :get,
+              class: "uk-button uk-button-primary uk-button-large uk-margin-top" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       resources :posts, only: [:index, :create, :destroy]
     end
 
+    get '/group_posts', to: "posts#group_posts", as: :posts
     resources :post_types, only: [:index, :create, :destroy]
 
     get '/evaluations/current', to: 'evaluations#current'

--- a/spec/requests/posts_controller_spec_spec.rb
+++ b/spec/requests/posts_controller_spec_spec.rb
@@ -1,0 +1,20 @@
+describe PostsController do
+
+  describe '#all_posts' do
+    before(:each) do
+      login_as(user)
+    end
+    let(:user) { group.leader.user }
+
+    context 'when the group exists' do
+      let(:group) { create(:group) }
+
+      it 'is ok' do
+        get "/groups/#{group.id}/group_posts"
+
+        expect(response).to have_http_status :ok
+        expect(response).to render_template :group_posts
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What's new?

We implemented a new post management system to enable group leaders and evaluation helpers to update multiple posts at one page.

Click on the new `Posztok kezelése` button on your group's page. 

![Screenshot from 2021-11-28 22-49-38](https://user-images.githubusercontent.com/48379676/143787568-c57a7bdd-0d3f-4eb8-8ed4-9b2ae9c14f92.png)

This will open the post management page, where all meberships and posts are listed in a table view. 
Just click on the post in  the row of the selected user to perform the action indicated between the parentheses.

![Screenshot from 2021-11-28 22-50-07](https://user-images.githubusercontent.com/48379676/143787451-0f39f7ba-745d-42e3-9ddd-fc29fc284675.png)

 We hope this makes administrating posts faster!

## Todos:

-  #373 
- #374 