### PR TITLE
show user and principle name on comment form

### DIFF
--- a/app/assets/javascripts/application/evaluation_comments.js
+++ b/app/assets/javascripts/application/evaluation_comments.js
@@ -3,10 +3,10 @@ var evaluationComments = (function($) {
   var selectedInput = null;
 
   module.init = function() {
-    $('.point-input').on('dblclick', onDoubleClick);
+    $('.point-input').on('click', onClick);
   }
 
-  function onDoubleClick() {
+  function onClick() {
     selectElement(this);
     fetchComments(this);
   }

--- a/app/controllers/point_detail_comments_controller.rb
+++ b/app/controllers/point_detail_comments_controller.rb
@@ -4,6 +4,8 @@ class PointDetailCommentsController < ApplicationController
 
   def index
     comments = comments_by_principle_user_id(params[:principle_id].to_i, params[:user_id].to_i)
+    @user = User.find(params[:user_id])
+    @principle = Principle.find(params[:principle_id])
     @point_detail_comments = PointDetailCommentDecorator.decorate_collection(comments)
     @point_detail_comment = PointDetailComment.new
     render layout: false

--- a/app/views/point_detail_comments/index.html.erb
+++ b/app/views/point_detail_comments/index.html.erb
@@ -1,3 +1,4 @@
+<div class="uk-padding uk-text-center"><%= @user.full_name %> - <%= @principle.name  %></div>
 <% @point_detail_comments.each do |point_detail_comment| %>
   <%= render 'show', comment: point_detail_comment %>
 <% end %>


### PR DESCRIPTION
What is new?

- The name of the selected user and principle are shown in the comment form to help group leaders
- UX improvemnet: The form is opened on click intead of double click

![Screenshot from 2022-01-09 10-23-12 - 1](https://user-images.githubusercontent.com/48379676/148676651-df692430-e1dd-4f0a-aa8f-261ef577944e.png)
