### PR TITLE
fix svie pdf redirects

### DIFF
--- a/app/controllers/svie_controller.rb
+++ b/app/controllers/svie_controller.rb
@@ -15,7 +15,7 @@ class SvieController < ApplicationController
     end
 
     current_user.svie.create_request(params[:svie_member_type])
-    redirect_to svie_index_path, notice: t(:applied_succesful)
+    redirect_to svie_edit_path, notice: t(:applied_succesful)
   end
 
   def edit
@@ -38,6 +38,10 @@ class SvieController < ApplicationController
   end
 
   def application_pdf
+    unless current_user.svie_post_request
+      return redirect_to svie_edit_path, notice: t(:svie_post_request_needed_for_pdf)
+    end
+
     pdf    = GenerateMembershipPdf.new(current_user)
     @user  = current_user
     @title = pdf.title

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -22,6 +22,7 @@ hu:
   accept_application: SVIE tag lett!
   abort_application: tagsági kérelme elutasítva!
   svie_group_needed: SVIE jelentkezéshez legalább egy SVIE körben tagnak kell lenned!
+  svie_post_request_needed_for_pdf: A PDF letöltéséhez mentsd el az elsődleges körödet!
   bad_date_format: Hibás dátum formátum! (YYYY. mm. dd)
   no_changes: Nincs változtatás!
   not_evaluation_season: Nincs bírálási időszak!


### PR DESCRIPTION
We got some errors on Rollbar in the `applicaton_pdf` action.
We redirected the user to the pdf page before he had a `svie_post_request` which is required for generating the pdf. 
I fixed the redirection and added a guard to the pdf endpoint.