### PR TITLE
permit helpers at resort to view evaluations

### DIFF
--- a/app/policies/evaluation_policy.rb
+++ b/app/policies/evaluation_policy.rb
@@ -126,12 +126,8 @@ class EvaluationPolicy < ApplicationPolicy
     cache { Group.resorts.include?(evaluation.group.parent)}
   end
 
-  def group_is_a_resort?
-    Group.resorts.include?(evaluation.group.parent)
-  end
-
   def evaluation_helper_at_resort?
-    return false unless group_is_a_resort?
+    return false unless group_is_a_resort_member?
 
     membership = Membership.find_by(group: evaluation.group.parent, user: user)
     return false unless membership

--- a/app/policies/evaluation_policy.rb
+++ b/app/policies/evaluation_policy.rb
@@ -3,7 +3,8 @@ class EvaluationPolicy < ApplicationPolicy
     return false if off_season?
 
     return true if leader_of_the_group? || evaluation_helper_of_the_group?
-    return true if leader_of_the_resort? || leader_in_the_resort? || evaluation_helper_in_the_resort?
+    return true if leader_of_the_resort? || leader_in_the_resort?
+    return true if evaluation_helper_in_the_resort? || evaluation_helper_at_resort?
     return true if pek_admin? || rvt_member?
 
     false
@@ -123,6 +124,19 @@ class EvaluationPolicy < ApplicationPolicy
 
   def group_is_a_resort_member?
     cache { Group.resorts.include?(evaluation.group.parent)}
+  end
+
+  def group_is_a_resort?
+    Group.resorts.include?(evaluation.group.parent)
+  end
+
+  def evaluation_helper_at_resort?
+    return false unless group_is_a_resort?
+
+    membership = Membership.find_by(group: evaluation.group.parent, user: user)
+    return false unless membership
+
+    membership.has_post?(PostType::EVALUATION_HELPER_ID)
   end
 
   def rvt_member?

--- a/spec/policies/evaluation_policy_spec.rb
+++ b/spec/policies/evaluation_policy_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe EvaluationPolicy, type: :policy do
       it { is_expected.to permit_actions(evaluation_view_actions) }
       it { is_expected.to forbid_actions(all_action - evaluation_view_actions) }
     end
+
+    context 'when the user is evaluation helper at resort?' do
+      let(:user) do
+        evaluation.group.parent.memberships.select(&:evaluation_helper?).first.user
+      end
+
+      it { is_expected.to permit_action(:show) }
+    end
   end
 
   context 'when evaluation season' do


### PR DESCRIPTION
Permit helpers at resort to view evaluations.
If a user has evaluation helper post at the resort he can see the evaluations for the groups that belong to the resort.