### PR TITLE
replace form link to email on login page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,11 +8,11 @@
         Örömmel köszöntünk a megújult PéK alkalmazás oldalán. Hosszú és
         gyümölcsöző folyamatot tudhatunk magunk mögött, melynek eredménye ez az
         oldal. Viszont mivel nem vagyunk tökéletesek, így lehetnek benne elvétve
-        hibák, ezeket <a href="https://goo.gl/forms/0pP8bDKAD7jzprPK2">itt</a>
+        hibák, ezeket a <a>kir-dev[kukac]sch.bme.hu</a> levelelező listán
         tudod jelezni felénk.
       </div>
       <div class="uk-width-medium-2-3 uk-text-center uk-container-center uk-text-small uk-margin">
-          (Ezen felül ha kedvet kaptál a webfejlesztéshez <a href="mailto:kir-dev@sch.bme.hu">itt</a> jelentkezhetsz csapatunkba.)
+          (Ezen felül ha kedvet kaptál a webfejlesztéshez a <a>kir-dev[kukac]sch.bme.hu</a> címen jelentkezhetsz csapatunkba.)
       </div>
       <div class="uk-width-1-1">
         <%= button_to "Bejelentkezés", oauth_login_path, class:"uk-button uk-button-large uk-button-primary uk-width-medium-1-4 uk-align-center uk-width-1-1" %>


### PR DESCRIPTION
I noticed that the old form were present on the login page, so I refactored it to our mailing list in order to be consistent.
I have used the [kukac] notation  for @, becasue this page can be accessed without login, and the email could be scraped by bots.