### PR TITLE
fix multiple financial officer issue

### DIFF
--- a/app/assets/javascripts/application/posts.js
+++ b/app/assets/javascripts/application/posts.js
@@ -50,5 +50,11 @@ function addPost(group_id, membership_id, post_type_id) {
                 button.disabled = false
             });
         }
+        if(response.status == 403){
+            response.json().then(data => {
+                UIkit.notify({message: data.message, timeout: 3000, status: 'danger'})
+                button.disabled = false
+            })
+        }
     })
 }

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -91,3 +91,6 @@ hu:
       next: "Következő &raquo;"
       last: "Utolsó"
       truncate: "..."
+  services:
+    create_post:
+      post_already_taken: 'Ezt a posztot már kiosztottad valakinek! Vissza kell venned a jelenlegi posztot, hogy újra kiosztható legyen.'

--- a/lib/tasks/remove_financial_officers_if_more_then_one.rake
+++ b/lib/tasks/remove_financial_officers_if_more_then_one.rake
@@ -1,0 +1,18 @@
+namespace :pek do
+  desc "This task removes the financial officers from each group where there is more than one"
+  task remove_financial_officers: :environment do
+    puts 'Starting to remove unused financial officers...'
+    groups_with_fo_count = Group.joins(memberships: :posts)
+                                .where('posts.post_type_id': PostType::FINANCIAL_OFFICER_POST_ID)
+                                .group('memberships.group_id').count('groups.id')
+    group_ids_with_more_fo = groups_with_fo_count.select { |k, v| v > 1 }.keys
+    groups_with_more_fo = Group.where(id: group_ids_with_more_fo)
+    groups_with_more_fo.each do |group|
+      fo_posts = Post.where('memberships.group_id': group.id,
+                            post_type_id: PostType::FINANCIAL_OFFICER_POST_ID)
+                     .joins(:membership).order('posts.id': :asc)
+      fo_posts[0..-2].each { |post| post.destroy! }
+    end
+    puts 'Finished removing unused financial officers!'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     FactoryBot.create(:post_type_leader)
+    FactoryBot.create(:post_type_financial_officer)
     FactoryBot.create(:post_type_newbie)
     FactoryBot.create(:post_type_evaluation_helper)
     FactoryBot.create(:group_svie)
@@ -63,6 +64,7 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
+    Post.delete_all
     PostType.delete_all
     Group.delete_all
     User.delete_all

--- a/spec/requests/post_type_controller_spec.rb
+++ b/spec/requests/post_type_controller_spec.rb
@@ -55,6 +55,7 @@ describe PostTypesController do
       let(:group) { create(:group) }
       let(:user) { group.leader.user }
       before(:each) { login_as(user) }
+      before(:each) { PostType.destroy(PostType::FINANCIAL_OFFICER_POST_ID) }
 
       it 'redirects back' do
         post "/groups/#{group.id}/post_types", params: {

--- a/spec/requests/posts_controller_spec_spec.rb
+++ b/spec/requests/posts_controller_spec_spec.rb
@@ -15,6 +15,65 @@ describe PostsController do
         expect(response).to have_http_status :ok
         expect(response).to render_template :group_posts
       end
+
+      describe '#create' do
+        let(:membership) { group.memberships.first }
+        it 'creates a post and redirects' do
+          expect {
+            post "/groups/#{group.id}/memberships/#{membership.id}/posts",
+                 params: { post_type_id: PostType::FINANCIAL_OFFICER_POST_ID }
+          }.to change {
+            membership.posts.count
+          }.by(1)
+          expect(response).to redirect_to("/groups/#{group.id}/memberships/#{membership.id}/posts")
+        end
+
+        it 'when the post is for the leader it redirects to the group page' do
+          post "/groups/#{group.id}/memberships/#{membership.id}/posts",
+               params: { post_type_id: PostType::LEADER_POST_ID }
+
+          expect(response).to redirect_to("/groups/#{group.id}")
+        end
+
+        context 'when FINANCIAL_OFFICER is present' do
+          before(:each) do
+            CreatePost::call(group, membership, PostType::FINANCIAL_OFFICER_POST_ID)
+          end
+          it 'creating another FINANCIAL_OFFICER is not processed' do
+            expect {
+              post "/groups/#{group.id}/memberships/#{membership.id}/posts",
+                   params: { post_type_id: PostType::FINANCIAL_OFFICER_POST_ID }
+            }.to change {
+              membership.posts.count
+            }.by(0)
+
+            expect(flash[:notice]).to eql(I18n.t('services.create_post.post_already_taken'))
+            expect(response).to redirect_to("/groups/#{group.id}/memberships/#{membership.id}/posts")
+          end
+        end
+
+        context 'when format is json ' do
+          it 'sends back the post id' do
+            post "/groups/#{group.id}/memberships/#{membership.id}/posts.json",
+                 params: { post_type_id: PostType::FINANCIAL_OFFICER_POST_ID }
+
+            expect(response.body).to eql({ post_id: Post.last.id }.to_json)
+          end
+
+          context 'when FINANCIAL_OFFICER is present' do
+            before(:each) do
+              CreatePost::call(group, membership, PostType::FINANCIAL_OFFICER_POST_ID)
+            end
+            it 'creating another FINANCIAL_OFFICER is forbidden' do
+              post "/groups/#{group.id}/memberships/#{membership.id}/posts.json",
+                   params: { post_type_id: PostType::FINANCIAL_OFFICER_POST_ID }
+
+              expect(response).to have_http_status :forbidden
+              expect(response.body).to eql({ message: I18n.t('services.create_post.post_already_taken') }.to_json)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/factories/post_types.rb
+++ b/test/factories/post_types.rb
@@ -7,7 +7,15 @@ FactoryBot.define do
     sequence(:id, 150)
   end
 
-  factory :post_type_leader, parent: :post_type do
+  factory :common_post_type, parent: :post_type do
+    group { nil }
+  end
+  factory :post_type_financial_officer, parent: :common_post_type do
+    id { PostType::FINANCIAL_OFFICER_POST_ID }
+    name { 'Gazdasagis' }
+  end
+
+  factory :post_type_leader, parent: :common_post_type do
     id { PostType::LEADER_POST_ID }
     name { 'Korvezeto' }
   end
@@ -17,20 +25,19 @@ FactoryBot.define do
     name { 'Feldolgozas alatt' }
   end
 
-  factory :post_type_pek_admin, parent: :post_type do
+  factory :post_type_pek_admin, parent: :common_post_type do
     group { Group.kirdev }
     id { PostType::PEK_ADMIN_ID }
     name { 'PeK admin' }
   end
 
-  factory :post_type_new_member, parent: :post_type do
+  factory :post_type_new_member, parent: :common_post_type do
     id { PostType::NEW_MEMBER_ID }
     name { 'Ujonc' }
   end
 
-  factory :post_type_evaluation_helper, parent: :post_type do
+  factory :post_type_evaluation_helper, parent: :common_post_type do
     id { PostType::EVALUATION_HELPER_ID }
-    group { nil }
     name { 'Pontozó' }
   end
 end


### PR DESCRIPTION
## What is new?

- Prevent group leaders to add a finacial officer post if it is already taken
- Create a migration to remove all but the latest financial officer from each group

## Notes
- It would be better to gurarante in the db level that a group can have only one financial officer but the schema makes implementing this hard. We should explore the solutions separately.


