### PR TITLE
Add pagination and search  to evaluation table

### DIFF
--- a/app/assets/stylesheets/evaluation_table.css
+++ b/app/assets/stylesheets/evaluation_table.css
@@ -150,3 +150,29 @@ input[type=number] {
   margin-right: 1px;
   visibility: visible;
 }
+#evaluation-table-filter-options {
+  display: flex;
+  justify-content: space-between;
+  max-width: 1000px;
+  margin: 2rem auto;
+  gap: 2rem;
+}
+#evaluation-table-user-search-form {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  margin: 0 auto;
+  gap: 2rem;
+  max-width: 500px;
+}
+#evaluation-table-user-search-form > .input-column {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.input-column > .start-with {
+  display: flex;
+  gap: 1rem;
+  margin-top: .5rem;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,8 @@
 #
 
 class User < ApplicationRecord
+  paginates_per 50
+
   scope :primary_svie_members, -> { where.not(svie_primary_membership: nil) }
 
   acts_as_target
@@ -80,6 +82,11 @@ class User < ApplicationRecord
   # Before validation need to fix cell phone numbers
   # validates_format_of :cell_phone, with: %r{\A\+?[0-9x]+$\z}, allow_blank: true
   validates_format_of :screen_name, without: %r{[\\/]+}
+
+  def self.with_full_name
+    full_names = select('*', "lower(concat(lastname,' ',firstname)) as full_name ")
+    from(full_names, :users)
+  end
 
   def full_name
     "#{lastname} #{firstname}"

--- a/app/views/evaluations/table.html.erb
+++ b/app/views/evaluations/table.html.erb
@@ -1,7 +1,7 @@
 <% stylesheet 'evaluation' %>
 <% stylesheet 'evaluation_table' %>
 
-<h1>Pontozás - <%= @evaluation.group.name %></h1>
+<h1 class="uk-margin-left">Pontozás - <%= @evaluation.group.name %></h1>
 
 <div id="content-main" class="uk-panel uk-panel-box">
   <div class="uk-clearfix uk-margin-bottom">
@@ -26,7 +26,25 @@
       <%= link_to 'Vissza', group_evaluations_current_path(current_group), class: 'uk-button uk-button-small' %>
     </div>
   </div>
-
+  <div id='evaluation-table-filter-options'>
+      <%= form_with id: 'evaluation-table-user-search-form',
+                    url: group_evaluation_table_path, method: :get, local: true,
+                    class: 'uk-form' do |form| %>
+        <div class="input-column">
+          <%= form.text_field :term, value: @search.term %>
+          <div class="start-with">
+            <%= form.label :start_with, "Csak a név elején" %>
+            <%= form.check_box :start_with, { checked: @search.start_with? }, true, false %>
+          </div>
+        </div>
+        <div>
+          <%= form.submit "Keresés", class: 'uk-button uk-button-primary' %>
+        </div>
+      <% end %>
+    <div>
+      <%= paginate @users_for_pagination %>
+    </div>
+  </div>
   <div class="uk-grid uk-grid-collapse uk-padding-remove uk-margin-remove">
     <div id="name-list-container">
       <ul class="uk-list uk-list-striped uk-text-bold" id="name-list">
@@ -171,9 +189,12 @@
           </tr>
         </tfoot>
       </table>
-    </div>`
+    </div>
   </div>
   <div id="save-icon"></div>
+</div>
+<div class="uk-margin-large-top">
+  <%= paginate @users_for_pagination %>
 </div>
 
 <div class="dark shadow" id="comment-float">


### PR DESCRIPTION
##  What is new
- Users are paginated on the evaluation page (each page has 50 users)
- There is a search field to find find users by name
  - There is a strat_with option that only checks the start of the name
  - This could be useful to find users whose name start with a specific letter
  
## Todo
- Deploy hungarian collation to prod env, this will be done in a separate PR