### PR TITLE
add dev button to quickly impersonate user

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -31,6 +31,12 @@
             <%= im_account.account %>
           <% end %>
           <%= @user_presenter.delegated_for %>
+          <% if Rails.env.development?  && current_user.id != @user_presenter.id %>
+            <%= form_tag(impersonate_user_path) do %>
+              <%= hidden_field_tag :user_id, @user_presenter.id %>
+              <%= submit_tag "Impersonate this user", class: 'uk-button uk-button-primary uk-margin-small uk-margin-left' %>
+            <% end %>
+          <% end %>
         </div>
 
         <div class="uk-width-1-1 uk-margin-top">


### PR DESCRIPTION
Sometimes during development we need  to test different policies, and we have to search for user, copy id, and go to development page to impersonate user.

This PR puts a button in dev mode next to user image which helps to one click imperonate a user