### PR TITLE
Fix auth.sch login

### DIFF
--- a/config/initializers/oauth.rb
+++ b/config/initializers/oauth.rb
@@ -11,7 +11,7 @@ module OmniAuth
       option :provider_ignores_state, true
 
       def request_phase
-        super
+        redirect client.auth_code.authorize_url(authorize_params)
       end
 
       def authorize_params


### PR DESCRIPTION
Auth.sch has been updated to conform more closely to the Oauth2 specification by allowing dynamic configuration as described [in the RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.3).
This changes the flow by no longer ignoring the redirect_uri parameter sent with the authorization request.
This means that according to the spec if the authorization request contains a redirect_uri parameter then the subsequent token request must contain that as well.

The underlying omniauth-oauth2 send the redirect uri with the auth request but omits it in the token request, this causes the login to fail.

This PR addresses the issue simply by overriding the default library behaviour and explicitly removing the redirect_uri from the auth request and thus solving the issue.
I did not find where in the library I can modify the token request, but that is what would be needed to take advantage of the Dynamic configuration feature