### PR TITLE
prevent evaluation duplication

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -5,6 +5,7 @@
 #  id                   :bigint           not null, primary key
 #  entry_request_status :string(255)
 #  explanation          :text
+#  idx_in_semester      :integer          default(0), not null
 #  is_considered        :boolean          default(FALSE), not null
 #  justification        :text             not null
 #  last_evaulation      :datetime
@@ -21,9 +22,10 @@
 #
 # Indexes
 #
-#  ert_semester_idx  (semester)
-#  next_version_idx  (next_version)
-#  unique_idx        (group_id,semester,next_version NULLS FIRST) UNIQUE
+#  ert_semester_idx                                                (semester)
+#  index_evaluations_on_group_id_and_semester_and_idx_in_semester  (group_id,semester,idx_in_semester) UNIQUE
+#  next_version_idx                                                (next_version)
+#  unique_idx                                                      (group_id,semester,next_version NULLS FIRST) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20240707094123_add_unique_index_on_evaluation_semester.rb
+++ b/db/migrate/20240707094123_add_unique_index_on_evaluation_semester.rb
@@ -1,0 +1,23 @@
+class AddUniqueIndexOnEvaluationSemester < ActiveRecord::Migration[6.0]
+  # We have multiple evaluations for the same group in the same semester from previous years,
+  # this prevents us from using a unique index on [:group_id, :semester].
+  # The idx_in_semester columns solves this by setting an arbitrary value where duplication is present and
+  # 0 for cases with no duplication.'
+  def up
+    add_column :evaluations, :idx_in_semester, :integer, default: 0, null: false
+
+    evaluation_groups = Evaluation.all.group_by { |evaluation| [evaluation.group_id, evaluation.semester] }
+    evaluation_groups.each do |id, evaluations|
+      evaluations.each.with_index do |evaluation, index|
+        evaluation.update!(idx_in_semester: index)
+      end
+    end
+
+    add_index :evaluations, [:group_id, :semester, :idx_in_semester], unique: true
+  end
+
+  def down
+    remove_index :evaluations, column: [:group_id, :semester, :idx_in_semester]
+    remove_column :evaluations, :idx_in_semester
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -134,7 +134,8 @@ CREATE TABLE public.evaluations (
     next_version bigint,
     explanation text,
     optlock integer DEFAULT 0 NOT NULL,
-    is_considered boolean DEFAULT false NOT NULL
+    is_considered boolean DEFAULT false NOT NULL,
+    idx_in_semester integer DEFAULT 0 NOT NULL
 );
 
 
@@ -1249,6 +1250,13 @@ CREATE UNIQUE INDEX index_entry_requests_on_evaluation_id_and_user_id ON public.
 
 
 --
+-- Name: index_evaluations_on_group_id_and_semester_and_idx_in_semester; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_evaluations_on_group_id_and_semester_and_idx_in_semester ON public.evaluations USING btree (group_id, semester, idx_in_semester);
+
+
+--
 -- Name: index_notifications_on_group_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1754,6 +1762,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221206081834'),
 ('20221209072919'),
 ('20221209100356'),
-('20240419155504');
+('20240419155504'),
+('20240707094123');
 
 

--- a/spec/requests/evalutations_controller_spec.rb
+++ b/spec/requests/evalutations_controller_spec.rb
@@ -159,7 +159,7 @@ describe EvaluationsController do
 
     before(:each) do
       evaluation.update!(id:2)
-      previous_evaluation = create(:evaluation, group: group, id: 1 )
+      previous_evaluation = create(:evaluation, group: group, id: 1, semester: '201720182')
       Principle.create!(evaluation: previous_evaluation,
                         name: 'Previous principle',
                         type: Principle::WORK,


### PR DESCRIPTION
Fixes #441 .
I added a new index to prevent duplicated evaluations for the same group in the same semester. 
There was a similar index unique_idx   on  (group_id,semester,next_version). I think this is a remenant of a feature from an older version. Since next_version can be null, uniqness is not enforced as stated in the [docs](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS):

> In general, a unique constraint is violated if there is more than one row in the table where the values of all of the columns included in the constraint are equal. By default, two null values are not considered equal in this comparison. That means even in the presence of a unique constraint it is possible to store duplicate rows that contain a null value in at least one of the constrained columns. This behavior can be changed by adding the clause NULLS NOT DISTINCT.