### PR TITLE
only return accepted entry requests to AuthSch

### DIFF
--- a/app/controllers/auth_sch_services_controller.rb
+++ b/app/controllers/auth_sch_services_controller.rb
@@ -20,7 +20,7 @@ class AuthSchServicesController < ApplicationController
 
   def entrants_json(user, semester)
     entrants = user.entry_requests.select do |er|
-      er.evaluation.accepted && er.evaluation.semester == semester
+      er.evaluation.accepted && er.evaluation.entry_request_accepted? && er.evaluation.semester == semester
     end
     entrant_array = []
     entrants.each do |entrant|

--- a/spec/requests/auth_sch_services_spec.rb
+++ b/spec/requests/auth_sch_services_spec.rb
@@ -77,7 +77,7 @@ describe AuthSchServicesController do
         user          = create(:user)
         group         = create(:group)
         membership    = create(:membership, group: group, user: user)
-        evaluation    = create(:evaluation, :accepted, group: group)
+        evaluation    = create(:evaluation, :accepted, group: group, entry_request_status:  Evaluation::ACCEPTED)
         entry_request = EntryRequest.create(user: user, evaluation: evaluation)
 
         expected_response = [


### PR DESCRIPTION
We returned non-accepted entry requests for user to AuthSch.
It was requested to only return accepted entry requests to make sure services using this info only see the accepted requests.